### PR TITLE
Fix Java VM parameters passing to the 'run' gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,12 @@ subprojects {
         
         compile files("$rootDir/network/src/main/resources/resource.jar")
     }
+
+    tasks.withType(JavaExec) {
+        // Assign all Java system properties from
+        // the command line to the JavaExec task.
+        systemProperties System.properties
+    }
 }
 
 // IDEA project configuration.


### PR DESCRIPTION
Add redirecting gradle `System.properties` to the java application `System.properties` for all the `JavaExec` gradle tasks.
Now `gradlew quickstart-swing:run -Djxbrowser.license.key=<your_license_key>` command line executes and passes `license_key` to the java application properly.