### PR TITLE
Add the default OpenPopupCallback implementations

### DIFF
--- a/callbacks/src/main/java/javafx/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/javafx/DefaultOpenPopupCallback.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2020, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package javafx;
+
+import com.teamdev.jxbrowser.browser.Browser;
+import com.teamdev.jxbrowser.browser.callback.CreatePopupCallback;
+import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback;
+import com.teamdev.jxbrowser.browser.event.BrowserClosed;
+import com.teamdev.jxbrowser.browser.event.TitleChanged;
+import com.teamdev.jxbrowser.browser.event.UpdateBoundsRequested;
+import com.teamdev.jxbrowser.os.Environment;
+import com.teamdev.jxbrowser.ui.Rect;
+import com.teamdev.jxbrowser.view.javafx.BrowserView;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+/**
+ * The default {@link CreatePopupCallback} implementation for the Swing UI toolkit that creates and shows a new window
+ * with the embedded popup browser.
+ */
+public final class DefaultOpenPopupCallback implements OpenPopupCallback {
+
+    private static final int DEFAULT_POPUP_WIDTH = 800;
+    private static final int DEFAULT_POPUP_HEIGHT = 600;
+
+    private static void updateBounds(Stage stage, Rect bounds) {
+        if (bounds.size().isEmpty()) {
+            stage.setWidth(DEFAULT_POPUP_WIDTH);
+            stage.setHeight(DEFAULT_POPUP_HEIGHT);
+        } else {
+            stage.setX(bounds.origin().x());
+            stage.setY(bounds.origin().y());
+            stage.setWidth(bounds.size().width());
+            stage.setHeight(bounds.size().height());
+        }
+    }
+
+    @Override
+    public Response on(Params params) {
+        Browser browser = params.popupBrowser();
+        Platform.runLater(() -> {
+            BrowserView view = BrowserView.newInstance(browser);
+            Stage stage = new Stage();
+            StackPane root = new StackPane();
+            Scene scene = new Scene(root);
+            root.getChildren().add(view);
+            stage.setScene(scene);
+
+            updateBounds(stage, params.initialBounds());
+
+            stage.setOnCloseRequest(event -> {
+                if (Environment.isWindows()) {
+                    new Thread(browser::close).start();
+                } else {
+                    browser.close();
+                }
+            });
+            browser.on(TitleChanged.class, event ->
+                    Platform.runLater(() -> stage.setTitle(event.title())));
+            browser.on(BrowserClosed.class, event ->
+                    Platform.runLater(stage::close));
+            browser.on(UpdateBoundsRequested.class, event ->
+                    Platform.runLater(() -> updateBounds(stage, event.bounds())));
+            stage.show();
+        });
+        return Response.proceed();
+    }
+}

--- a/callbacks/src/main/java/javafx/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/javafx/DefaultOpenPopupCallback.java
@@ -21,7 +21,6 @@
 package javafx;
 
 import com.teamdev.jxbrowser.browser.Browser;
-import com.teamdev.jxbrowser.browser.callback.CreatePopupCallback;
 import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback;
 import com.teamdev.jxbrowser.browser.event.BrowserClosed;
 import com.teamdev.jxbrowser.browser.event.TitleChanged;
@@ -35,7 +34,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 /**
- * The default {@link CreatePopupCallback} implementation for the Swing UI toolkit that creates and shows a new window
+ * The default {@link OpenPopupCallback} implementation for the Swing UI toolkit that creates and shows a new window
  * with the embedded popup browser.
  */
 public final class DefaultOpenPopupCallback implements OpenPopupCallback {

--- a/callbacks/src/main/java/javafx/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/javafx/DefaultOpenPopupCallback.java
@@ -25,7 +25,6 @@ import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback;
 import com.teamdev.jxbrowser.browser.event.BrowserClosed;
 import com.teamdev.jxbrowser.browser.event.TitleChanged;
 import com.teamdev.jxbrowser.browser.event.UpdateBoundsRequested;
-import com.teamdev.jxbrowser.os.Environment;
 import com.teamdev.jxbrowser.ui.Rect;
 import com.teamdev.jxbrowser.view.javafx.BrowserView;
 import javafx.application.Platform;
@@ -34,7 +33,7 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
 /**
- * The default {@link OpenPopupCallback} implementation for the Swing UI toolkit that creates and shows a new window
+ * The default {@link OpenPopupCallback} implementation for the JavaFX UI toolkit that creates and shows a new window
  * with the embedded popup browser.
  */
 public final class DefaultOpenPopupCallback implements OpenPopupCallback {
@@ -55,19 +54,16 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
 
             updateBounds(stage, params.initialBounds());
 
-            stage.setOnCloseRequest(event -> {
-                if (Environment.isWindows()) {
-                    new Thread(browser::close).start();
-                } else {
-                    browser.close();
-                }
-            });
+            stage.setOnCloseRequest(event -> browser.close());
             browser.on(TitleChanged.class, event ->
-                    Platform.runLater(() -> stage.setTitle(event.title())));
+                    Platform.runLater(() -> stage.setTitle(event.title()))
+            );
             browser.on(BrowserClosed.class, event ->
-                    Platform.runLater(stage::close));
+                    Platform.runLater(stage::close)
+            );
             browser.on(UpdateBoundsRequested.class, event ->
-                    Platform.runLater(() -> updateBounds(stage, event.bounds())));
+                    Platform.runLater(() -> updateBounds(stage, event.bounds()))
+            );
             stage.show();
         });
         return Response.proceed();

--- a/callbacks/src/main/java/javafx/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/javafx/DefaultOpenPopupCallback.java
@@ -42,18 +42,6 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
     private static final int DEFAULT_POPUP_WIDTH = 800;
     private static final int DEFAULT_POPUP_HEIGHT = 600;
 
-    private static void updateBounds(Stage stage, Rect bounds) {
-        if (bounds.size().isEmpty()) {
-            stage.setWidth(DEFAULT_POPUP_WIDTH);
-            stage.setHeight(DEFAULT_POPUP_HEIGHT);
-        } else {
-            stage.setX(bounds.origin().x());
-            stage.setY(bounds.origin().y());
-            stage.setWidth(bounds.size().width());
-            stage.setHeight(bounds.size().height());
-        }
-    }
-
     @Override
     public Response on(Params params) {
         Browser browser = params.popupBrowser();
@@ -83,5 +71,17 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
             stage.show();
         });
         return Response.proceed();
+    }
+
+    private static void updateBounds(Stage stage, Rect bounds) {
+        if (bounds.size().isEmpty()) {
+            stage.setWidth(DEFAULT_POPUP_WIDTH);
+            stage.setHeight(DEFAULT_POPUP_HEIGHT);
+        } else {
+            stage.setX(bounds.origin().x());
+            stage.setY(bounds.origin().y());
+            stage.setWidth(bounds.size().width());
+            stage.setHeight(bounds.size().height());
+        }
     }
 }

--- a/callbacks/src/main/java/swing/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/swing/DefaultOpenPopupCallback.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2020, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package swing;
+
+import com.teamdev.jxbrowser.browser.Browser;
+import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback;
+import com.teamdev.jxbrowser.browser.event.BrowserClosed;
+import com.teamdev.jxbrowser.browser.event.TitleChanged;
+import com.teamdev.jxbrowser.browser.event.UpdateBoundsRequested;
+import com.teamdev.jxbrowser.ui.Rect;
+import com.teamdev.jxbrowser.ui.Size;
+import com.teamdev.jxbrowser.view.swing.BrowserView;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+
+import static javax.swing.SwingUtilities.invokeLater;
+
+/**
+ * The default {@link OpenPopupCallback} implementation for the Swing UI toolkit that creates and shows a new window
+ * with the embedded popup browser.
+ */
+public final class DefaultOpenPopupCallback implements OpenPopupCallback {
+
+    private static final int DEFAULT_POPUP_WIDTH = 800;
+    private static final int DEFAULT_POPUP_HEIGHT = 600;
+
+    private static void updateBounds(JFrame frame, Rect bounds) {
+        Size size = bounds.size();
+        if (size.isEmpty()) {
+            frame.setLocationByPlatform(true);
+            frame.setSize(DEFAULT_POPUP_WIDTH, DEFAULT_POPUP_HEIGHT);
+        } else {
+            com.teamdev.jxbrowser.ui.Point origin = bounds.origin();
+            frame.setLocation(new Point(origin.x(), origin.y()));
+            Dimension dimension = new Dimension(size.width(), size.height());
+            frame.getContentPane().setPreferredSize(dimension);
+            frame.pack();
+        }
+    }
+
+    @Override
+    public Response on(Params params) {
+        Browser browser = params.popupBrowser();
+        invokeLater(() -> {
+            BrowserView view = BrowserView.newInstance(browser);
+            JFrame frame = new JFrame();
+            frame.add(view, BorderLayout.CENTER);
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    invokeLater(browser::close);
+                }
+            });
+
+            updateBounds(frame, params.initialBounds());
+
+            browser.on(TitleChanged.class, event ->
+                    invokeLater(() ->
+                            frame.setTitle(event.title())));
+            browser.on(BrowserClosed.class, event ->
+                    invokeLater(() -> {
+                        frame.setVisible(false);
+                        frame.dispose();
+                    }));
+            browser.on(UpdateBoundsRequested.class, event ->
+                    invokeLater(() -> updateBounds(frame, event.bounds())));
+            frame.setVisible(true);
+        });
+        return Response.proceed();
+    }
+}

--- a/callbacks/src/main/java/swing/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/swing/DefaultOpenPopupCallback.java
@@ -45,20 +45,6 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
     private static final int DEFAULT_POPUP_WIDTH = 800;
     private static final int DEFAULT_POPUP_HEIGHT = 600;
 
-    private static void updateBounds(JFrame frame, Rect bounds) {
-        Size size = bounds.size();
-        if (size.isEmpty()) {
-            frame.setLocationByPlatform(true);
-            frame.setSize(DEFAULT_POPUP_WIDTH, DEFAULT_POPUP_HEIGHT);
-        } else {
-            com.teamdev.jxbrowser.ui.Point origin = bounds.origin();
-            frame.setLocation(new Point(origin.x(), origin.y()));
-            Dimension dimension = new Dimension(size.width(), size.height());
-            frame.getContentPane().setPreferredSize(dimension);
-            frame.pack();
-        }
-    }
-
     @Override
     public Response on(Params params) {
         Browser browser = params.popupBrowser();
@@ -88,5 +74,19 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
             frame.setVisible(true);
         });
         return Response.proceed();
+    }
+
+    private static void updateBounds(JFrame frame, Rect bounds) {
+        Size size = bounds.size();
+        if (size.isEmpty()) {
+            frame.setLocationByPlatform(true);
+            frame.setSize(DEFAULT_POPUP_WIDTH, DEFAULT_POPUP_HEIGHT);
+        } else {
+            com.teamdev.jxbrowser.ui.Point origin = bounds.origin();
+            frame.setLocation(new Point(origin.x(), origin.y()));
+            Dimension dimension = new Dimension(size.width(), size.height());
+            frame.getContentPane().setPreferredSize(dimension);
+            frame.pack();
+        }
     }
 }

--- a/callbacks/src/main/java/swing/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/swing/DefaultOpenPopupCallback.java
@@ -61,16 +61,17 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
 
             updateBounds(frame, params.initialBounds());
 
-            browser.on(TitleChanged.class, event ->
-                    invokeLater(() ->
-                            frame.setTitle(event.title())));
-            browser.on(BrowserClosed.class, event ->
-                    invokeLater(() -> {
-                        frame.setVisible(false);
-                        frame.dispose();
-                    }));
-            browser.on(UpdateBoundsRequested.class, event ->
-                    invokeLater(() -> updateBounds(frame, event.bounds())));
+            browser.on(TitleChanged.class, event -> invokeLater(() ->
+                    frame.setTitle(event.title())
+            ));
+            browser.on(BrowserClosed.class, event -> invokeLater(() -> {
+                frame.setVisible(false);
+                frame.dispose();
+            }));
+            browser.on(UpdateBoundsRequested.class, event -> invokeLater(() ->
+                    updateBounds(frame, event.bounds())
+            ));
+
             frame.setVisible(true);
         });
         return Response.proceed();

--- a/callbacks/src/main/java/swt/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/swt/DefaultOpenPopupCallback.java
@@ -42,27 +42,6 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
     private static final int DEFAULT_POPUP_WIDTH = 800;
     private static final int DEFAULT_POPUP_HEIGHT = 600;
 
-    private static void updateBounds(Shell shell, BrowserView view, Rect bounds) {
-        shell.setLocation(bounds.x(), bounds.y());
-        if (bounds.size().isEmpty()) {
-            view.setSize(DEFAULT_POPUP_WIDTH, DEFAULT_POPUP_HEIGHT);
-        } else {
-            view.setSize(bounds.width(), bounds.height());
-        }
-    }
-
-    private static void asyncExec(Widget widget, Runnable doRun) {
-        try {
-            widget.getDisplay().asyncExec(() -> {
-                if (!widget.isDisposed()) {
-                    doRun.run();
-                }
-            });
-        } catch (SWTException ignore) {
-            // No op.
-        }
-    }
-
     @Override
     public Response on(Params params) {
         Browser browser = params.popupBrowser();
@@ -103,5 +82,26 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
             Response.proceed();
         }
         return Response.proceed();
+    }
+
+    private static void updateBounds(Shell shell, BrowserView view, Rect bounds) {
+        shell.setLocation(bounds.x(), bounds.y());
+        if (bounds.size().isEmpty()) {
+            view.setSize(DEFAULT_POPUP_WIDTH, DEFAULT_POPUP_HEIGHT);
+        } else {
+            view.setSize(bounds.width(), bounds.height());
+        }
+    }
+
+    private static void asyncExec(Widget widget, Runnable doRun) {
+        try {
+            widget.getDisplay().asyncExec(() -> {
+                if (!widget.isDisposed()) {
+                    doRun.run();
+                }
+            });
+        } catch (SWTException ignore) {
+            // No op.
+        }
     }
 }

--- a/callbacks/src/main/java/swt/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/swt/DefaultOpenPopupCallback.java
@@ -21,7 +21,6 @@
 package swt;
 
 import com.teamdev.jxbrowser.browser.Browser;
-import com.teamdev.jxbrowser.browser.callback.CreatePopupCallback;
 import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback;
 import com.teamdev.jxbrowser.browser.event.BrowserClosed;
 import com.teamdev.jxbrowser.browser.event.TitleChanged;
@@ -35,7 +34,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
 
 /**
- * The default {@link CreatePopupCallback} implementation for the Swing UI toolkit that creates and shows a new window
+ * The default {@link OpenPopupCallback} implementation for the Swing UI toolkit that creates and shows a new window
  * with the embedded popup browser.
  */
 public final class DefaultOpenPopupCallback implements OpenPopupCallback {

--- a/callbacks/src/main/java/swt/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/swt/DefaultOpenPopupCallback.java
@@ -34,7 +34,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Widget;
 
 /**
- * The default {@link OpenPopupCallback} implementation for the Swing UI toolkit that creates and shows a new window
+ * The default {@link OpenPopupCallback} implementation for the SWT UI toolkit that creates and shows a new window
  * with the embedded popup browser.
  */
 public final class DefaultOpenPopupCallback implements OpenPopupCallback {
@@ -61,10 +61,8 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
 
                 browser.on(TitleChanged.class, event ->
                         asyncExec(shell, () -> shell.setText(event.title())));
-
                 browser.on(BrowserClosed.class, event ->
                         asyncExec(shell, shell::dispose));
-
                 browser.on(UpdateBoundsRequested.class, event ->
                         asyncExec(shell, () -> updateBounds(shell, view, event.bounds())));
 
@@ -94,14 +92,10 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
     }
 
     private static void asyncExec(Widget widget, Runnable doRun) {
-        try {
-            widget.getDisplay().asyncExec(() -> {
-                if (!widget.isDisposed()) {
-                    doRun.run();
-                }
-            });
-        } catch (SWTException ignore) {
-            // No op.
-        }
+        widget.getDisplay().asyncExec(() -> {
+            if (!widget.isDisposed()) {
+                doRun.run();
+            }
+        });
     }
 }

--- a/callbacks/src/main/java/swt/DefaultOpenPopupCallback.java
+++ b/callbacks/src/main/java/swt/DefaultOpenPopupCallback.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2020, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package swt;
+
+import com.teamdev.jxbrowser.browser.Browser;
+import com.teamdev.jxbrowser.browser.callback.CreatePopupCallback;
+import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback;
+import com.teamdev.jxbrowser.browser.event.BrowserClosed;
+import com.teamdev.jxbrowser.browser.event.TitleChanged;
+import com.teamdev.jxbrowser.browser.event.UpdateBoundsRequested;
+import com.teamdev.jxbrowser.ui.Rect;
+import com.teamdev.jxbrowser.view.swt.BrowserView;
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Widget;
+
+/**
+ * The default {@link CreatePopupCallback} implementation for the Swing UI toolkit that creates and shows a new window
+ * with the embedded popup browser.
+ */
+public final class DefaultOpenPopupCallback implements OpenPopupCallback {
+
+    private static final int DEFAULT_POPUP_WIDTH = 800;
+    private static final int DEFAULT_POPUP_HEIGHT = 600;
+
+    private static void updateBounds(Shell shell, BrowserView view, Rect bounds) {
+        shell.setLocation(bounds.x(), bounds.y());
+        if (bounds.size().isEmpty()) {
+            view.setSize(DEFAULT_POPUP_WIDTH, DEFAULT_POPUP_HEIGHT);
+        } else {
+            view.setSize(bounds.width(), bounds.height());
+        }
+    }
+
+    private static void asyncExec(Widget widget, Runnable doRun) {
+        try {
+            widget.getDisplay().asyncExec(() -> {
+                if (!widget.isDisposed()) {
+                    doRun.run();
+                }
+            });
+        } catch (SWTException ignore) {
+            // No op.
+        }
+    }
+
+    @Override
+    public Response on(Params params) {
+        Browser browser = params.popupBrowser();
+        try {
+            Display display = Display.getDefault();
+            display.asyncExec(() -> {
+                Shell shell = new Shell(display);
+                shell.setLayout(new FillLayout());
+                BrowserView view = BrowserView.newInstance(shell, browser);
+                updateBounds(shell, view, params.initialBounds());
+
+                shell.addDisposeListener(event -> {
+                    if (!browser.isClosed()) {
+                        asyncExec(shell, browser::close);
+                    }
+                });
+
+                browser.on(TitleChanged.class, event ->
+                        asyncExec(shell, () -> shell.setText(event.title())));
+
+                browser.on(BrowserClosed.class, event ->
+                        asyncExec(shell, shell::dispose));
+
+                browser.on(UpdateBoundsRequested.class, event ->
+                        asyncExec(shell, () -> updateBounds(shell, view, event.bounds())));
+
+                view.setVisible(true);
+                shell.pack();
+                shell.open();
+
+                while (!shell.isDisposed()) {
+                    if (!display.readAndDispatch()) {
+                        display.sleep();
+                    }
+                }
+            });
+        } catch (SWTException ignore) {
+            Response.proceed();
+        }
+        return Response.proceed();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -36,6 +36,7 @@ include 'content'
 include 'printing'
 include 'chromium'
 include 'dom'
+include 'callbacks'
 include 'concepts'
 include 'javascript'
 include 'dialogs'
@@ -53,3 +54,4 @@ include 'input'
 
 module ('content-changes', './tutorials/content-changes')
 module ('eclipse-rcp', './tutorials/eclipse-rcp')
+

--- a/troubleshooting/src/main/java/RedirectLoggingToFile.java
+++ b/troubleshooting/src/main/java/RedirectLoggingToFile.java
@@ -21,11 +21,12 @@
 import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.engine.EngineOptions;
-import com.teamdev.jxbrowser.internal.Files;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 
 import javax.swing.*;
 import java.awt.*;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
@@ -39,8 +40,12 @@ import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
 public final class RedirectLoggingToFile {
 
     public static void main(String[] args) {
-        // Redirect Browser log messages to jxbrowser-browser.log
-        Path loggingDir = Files.createTempDir("jxbrowser-logs");
+        Path loggingDir;
+        try {
+            loggingDir = Files.createTempDirectory("jxbrowser-logs");
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create temporary directory", e);
+        }
         Path loggingFile = loggingDir.resolve("jxbrowser-browser.log");
         System.setProperty("jxbrowser.logging.file",
                 loggingFile.toAbsolutePath().toString());

--- a/troubleshooting/src/main/java/RedirectLoggingToFile.java
+++ b/troubleshooting/src/main/java/RedirectLoggingToFile.java
@@ -44,7 +44,7 @@ public final class RedirectLoggingToFile {
         try {
             loggingDir = Files.createTempDirectory("jxbrowser-logs");
         } catch (IOException e) {
-            throw new RuntimeException("Failed to create temporary directory", e);
+            throw new RuntimeException("Failed to create a temporary directory", e);
         }
         Path loggingFile = loggingDir.resolve("jxbrowser-browser.log");
         System.setProperty("jxbrowser.logging.file",

--- a/troubleshooting/src/main/java/RedirectLoggingToFile.java
+++ b/troubleshooting/src/main/java/RedirectLoggingToFile.java
@@ -46,7 +46,7 @@ public final class RedirectLoggingToFile {
         } catch (IOException e) {
             throw new RuntimeException("Failed to create a temporary directory", e);
         }
-        Path loggingFile = loggingDir.resolve("jxbrowser-browser.log");
+        Path loggingFile = loggingDir.resolve("jxbrowser.log");
         System.setProperty("jxbrowser.logging.file",
                 loggingFile.toAbsolutePath().toString());
 


### PR DESCRIPTION
We have the examples for the `OpenPopupCallback` implementation on the support portal. They should be kept up to date and not use the internal API. 
The purpose of this PR is to keep those examples up to date and allow adding them to the support portal automatically using the embedcode tool.
Additionally, all references to internal JxBrowser API are removed.