### PR TITLE
Add header and footer customization in the print settings example

### DIFF
--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -53,10 +53,10 @@ public final class PrintSettings {
                     .orElseThrow(IllegalStateException::new);
             PrintJob<HtmlSettings> printJob = printer.printJob();
             printJob.settings()
-                    .header("<span style=\"font-size: 12px;\">"
-                            + "Page header: <span class=\"title\"></span></div>")
-                    .footer("<span style=\"font-size: 12px;\">"
-                            + "Page footer: <span class=\"pageNumber\"></span></div>")
+                    .header("<span style='font-size: 12px;'>"
+                            + "Page header: <span class='title'></span></div>")
+                    .footer("<span style='font-size: 12px;'>"
+                            + "Page footer: <span class='pageNumber'></span></div>")
                     .paperSize(ISO_A4)
                     .colorModel(COLOR)
                     .enablePrintingBackgrounds()

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -53,10 +53,8 @@ public final class PrintSettings {
                     .orElseThrow(IllegalStateException::new);
             PrintJob<HtmlSettings> printJob = printer.printJob();
             printJob.settings()
-                    // Configure header with custom text and document title.
                     .header("<span style=\"font-size: 12px;\">"
                             + "Page header: <span class=\"title\"></span></div>")
-                    // Configure footer with custom text and the current page number.
                     .footer("<span style=\"font-size: 12px;\">"
                             + "Page footer: <span class=\"pageNumber\"></span></div>")
                     .paperSize(ISO_A4)

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -55,10 +55,10 @@ public final class PrintSettings {
             printJob.settings()
                     // Configure header with custom text and document title.
                     .header("<span style=\"font-size: 12px;\">"
-                            + "Page header: <span class=title></span></div>")
+                            + "Page header: <span class=\"title\"></span></div>")
                     // Configure footer with custom text and the current page number.
                     .footer("<span style=\"font-size: 12px;\">"
-                            + "Page footer: <span class=pageNumber></span></div>")
+                            + "Page footer: <span class=\"pageNumber\"></span></div>")
                     .paperSize(ISO_A4)
                     .colorModel(COLOR)
                     .enablePrintingBackgrounds()

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -53,6 +53,12 @@ public final class PrintSettings {
                     .orElseThrow(IllegalStateException::new);
             PrintJob<HtmlSettings> printJob = printer.printJob();
             printJob.settings()
+                    // Configure header with custom text and document title.
+                    .header("<span style=\"font-size: 12px;\">"
+                            + "Page header: <span class=title></span></div>")
+                    // Configure footer with custom text and the current page number.
+                    .footer("<span style=\"font-size: 12px;\">"
+                            + "Page footer: <span class=pageNumber></span></div>")
                     .paperSize(ISO_A4)
                     .colorModel(COLOR)
                     .enablePrintingBackgrounds()

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -53,10 +53,10 @@ public final class PrintSettings {
                     .orElseThrow(IllegalStateException::new);
             PrintJob<HtmlSettings> printJob = printer.printJob();
             printJob.settings()
-                    .header("<span style='font-size: 12px;'>"
-                            + "Page header: <span class='title'></span>")
-                    .footer("<span style='font-size: 12px;'>"
-                            + "Page footer: <span class='pageNumber'></span>")
+                    .header("<span style='font-size: 12px;'>Page header:</span>"
+                            + "<span class='title'></span>")
+                    .footer("<span style='font-size: 12px;'>Page footer:</span>"
+                            + "<span class='pageNumber'></span>")
                     .paperSize(ISO_A4)
                     .colorModel(COLOR)
                     .enablePrintingBackgrounds()

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -54,9 +54,9 @@ public final class PrintSettings {
             PrintJob<HtmlSettings> printJob = printer.printJob();
             printJob.settings()
                     .header("<span style='font-size: 12px;'>"
-                            + "Page header: <span class='title'></span></div>")
+                            + "Page header: <span class='title'></span>")
                     .footer("<span style='font-size: 12px;'>"
-                            + "Page footer: <span class='pageNumber'></span></div>")
+                            + "Page footer: <span class='pageNumber'></span>")
                     .paperSize(ISO_A4)
                     .colorModel(COLOR)
                     .enablePrintingBackgrounds()


### PR DESCRIPTION
In this PR we extend the print settings example by customizing the header and footer in the print settings.