### PR TITLE
Rewrite the screen-sharing example

### DIFF
--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
@@ -82,12 +82,7 @@ public final class ScreenSharing {
                         mainFrame.executeJavaScript(
                                 "document.getElementById('share-screen').click();"));
 
-                // Copy the screen sharing URL to a clipboard.
-                Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-                clipboard.setContents(new StringSelection(browser.url()), null);
-                String message = String.format(
-                        "You are sharing the screen.%nURL copied to clipboard.");
-                JOptionPane.showMessageDialog(frame, message);
+                showSuccessScreenSharingDialog(frame, browser.url());
             });
 
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
@@ -114,5 +109,28 @@ public final class ScreenSharing {
             throw new RuntimeException(e);
         }
         subscription.unsubscribe();
+    }
+
+    private static void showSuccessScreenSharingDialog(JFrame frame, String url) {
+        String title = "You are sharing the primary screen";
+        String message = String.format(
+                "Please share and open the following URL in Google Chrome to see your screen remotely:%n%s",
+                url);
+        String copyActionText = "Copy URL";
+        String closeActionText = "Close";
+
+        Object[] options = new Object[]{copyActionText, closeActionText};
+        int returnValue = JOptionPane.showOptionDialog(frame,
+                message,
+                title,
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.PLAIN_MESSAGE,
+                null,
+                options,
+                options[0]);
+        if (returnValue == JOptionPane.OK_OPTION) {
+            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+            clipboard.setContents(new StringSelection(url), null);
+        }
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
@@ -115,7 +115,7 @@ public final class ScreenSharing {
         invokeLater(() -> {
             String title = "You are sharing the primary screen";
             String message = String.format(
-                    "Please share and open the following URL in a web browser to see your screen remotely:%n%s",
+                    "Please open the following URL in a web browser to see your screen remotely:%n%s",
                     url);
             String copyActionText = "Copy URL";
             String closeActionText = "Close";

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
@@ -43,7 +43,8 @@ import javax.swing.JOptionPane;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to share the screen with a button click in the Swing application.
+ * This example demonstrates how to share a primary screen programmatically via WebRTC and generate
+ * a URL that can be opened remotely in a web browser app to observe the shared screen.
  */
 public final class ScreenSharing {
 
@@ -68,11 +69,12 @@ public final class ScreenSharing {
 
         invokeLater(() -> {
             JFrame frame = new JFrame("Screen Sharing Example");
-            JButton share = new JButton("Share screen");
+            JButton share = new JButton("Share My Screen...");
 
             share.addActionListener(e -> {
 
-                // Load the WebRTC Screen Sharing Demo and wait until the document in the main frame is loaded completely.
+                // Load the WebRTC Screen Sharing Demo
+                // and wait until the document in the main frame is loaded completely.
                 loadUrlAndWaitForDocument(browser, WEBRTC_SCREEN_SHARING_URL);
 
                 // Click the "Share Your Screen" button to start a capture session.
@@ -89,7 +91,7 @@ public final class ScreenSharing {
             });
 
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-            frame.setSize(600, 400);
+            frame.setSize(500, 300);
             frame.setLayout(new GridBagLayout());
             frame.add(share, new GridBagConstraints());
             frame.setLocationRelativeTo(null);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
@@ -112,25 +112,27 @@ public final class ScreenSharing {
     }
 
     private static void showSuccessScreenSharingDialog(JFrame frame, String url) {
-        String title = "You are sharing the primary screen";
-        String message = String.format(
-                "Please share and open the following URL in Google Chrome to see your screen remotely:%n%s",
-                url);
-        String copyActionText = "Copy URL";
-        String closeActionText = "Close";
+        invokeLater(() -> {
+            String title = "You are sharing the primary screen";
+            String message = String.format(
+                    "Please share and open the following URL in Google Chrome to see your screen remotely:%n%s",
+                    url);
+            String copyActionText = "Copy URL";
+            String closeActionText = "Close";
 
-        Object[] options = new Object[]{copyActionText, closeActionText};
-        int returnValue = JOptionPane.showOptionDialog(frame,
-                message,
-                title,
-                JOptionPane.OK_CANCEL_OPTION,
-                JOptionPane.PLAIN_MESSAGE,
-                null,
-                options,
-                options[0]);
-        if (returnValue == JOptionPane.OK_OPTION) {
-            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-            clipboard.setContents(new StringSelection(url), null);
-        }
+            Object[] options = new Object[]{copyActionText, closeActionText};
+            int returnValue = JOptionPane.showOptionDialog(frame,
+                    message,
+                    title,
+                    JOptionPane.OK_CANCEL_OPTION,
+                    JOptionPane.PLAIN_MESSAGE,
+                    null,
+                    options,
+                    options[0]);
+            if (returnValue == JOptionPane.OK_OPTION) {
+                Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+                clipboard.setContents(new StringSelection(url), null);
+            }
+        });
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
@@ -21,7 +21,6 @@
 package com.teamdev.jxbrowser.examples;
 
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
-import static java.lang.System.lineSeparator;
 import static javax.swing.SwingUtilities.invokeLater;
 
 import com.teamdev.jxbrowser.browser.Browser;
@@ -82,8 +81,8 @@ public final class ScreenSharing {
                 // Copy the screen sharing URL to a clipboard.
                 Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
                 clipboard.setContents(new StringSelection(WEBRTC_SCREEN_SHARING_URL), null);
-                JOptionPane.showMessageDialog(frame, "You are sharing the screen." + lineSeparator()
-                        + "URL copied to clipboard.");
+                String message = String.format("You are sharing the screen.%nURL copied to clipboard.");
+                JOptionPane.showMessageDialog(frame, message);
             });
 
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/ScreenSharing.java
@@ -76,7 +76,7 @@ public final class ScreenSharing {
 
         invokeLater(() -> {
             JFrame frame = new JFrame("Screen Sharing Example");
-            JButton share = new JButton("Share Your Screen");
+            JButton share = new JButton("Share screen");
 
             share.addActionListener(e -> {
                 countDownLatch = new CountDownLatch(1);


### PR DESCRIPTION
Previously, the example showed how to share a screen in one browser instance and spectate the result in another just by following the same link. We have rewritten the example to demonstrate how to share the screen with a button click in a Swing application.

Now we start a capture session on the Swing button click and load the WebRTC Screen Sharing Demo without embedding the `BrowserView`.

The view of the example application is shown below:

<img width="612" alt="Screenshot 2022-04-27 at 16 56 02" src="https://user-images.githubusercontent.com/93273044/165535410-9f330fca-e530-493e-aaaa-187c7344e7ee.png">

After clicking the button:

<img width="708" alt="Screenshot 2022-05-03 at 12 57 27" src="https://user-images.githubusercontent.com/93273044/166435172-6dbbc1a5-e62c-45fe-a193-bc8704f181eb.png">



