### PR TITLE
Use footnote links in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ The information in this repository is provided on the following terms: https://w
 [requirements]: https://jxbrowser-support.teamdev.com/docs/guides/introduction/requirements.html
 [idea]: https://www.jetbrains.com/help/idea/gradle.html#gradle_import
 [eclipse]: https://marketplace.eclipse.org/content/buildship-gradle-integration#group-details
-[netBeans]: https://netbeans.org/features/java/build-tools.html
+[netbeans]: https://netbeans.org/features/java/build-tools.html
 [get-evaluation]: https://www.teamdev.com/jxbrowser#evaluate

--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ With JxBrowser you can display modern web pages, PDFs, WebGL, work with DOM, Jav
 To run the examples please follow the instruction below:
 
 1. Make sure your environment meets the
-   [software and hardware requirements](https://jxbrowser-support.teamdev.com/docs/guides/introduction/requirements.html).
+   [software and hardware requirements][requirements].
 
 2. Clone this repository:
     ```bash
     git clone https://github.com/TeamDev-IP/JxBrowser-Examples
     ```
 3. Open the Gradle project in your favourite IDE:
-   - [Intellij IDEA](https://www.jetbrains.com/help/idea/gradle.html#gradle_import)
-   - [Eclipse](https://marketplace.eclipse.org/content/buildship-gradle-integration#group-details)
-   - [NetBeans](https://netbeans.org/features/java/build-tools.html)
+   - [Intellij IDEA][idea]
+   - [Eclipse][eclipse]
+   - [NetBeans][netbeans]
 
-4. [Get](https://www.teamdev.com/jxbrowser#evaluate) a free 30-day trial license key.
+4. [Get][get-evaluation] a free 30-day trial license key.
 
 5. To run an example please specify the `jxbrowser.license.key` VM parameter:
     ```bash
@@ -41,3 +41,10 @@ To run the examples please follow the instruction below:
 ## Terms and Privacy
 
 The information in this repository is provided on the following terms: https://www.teamdev.com/terms-and-privacy
+
+
+[requirements]: https://jxbrowser-support.teamdev.com/docs/guides/introduction/requirements.html
+[idea]: https://www.jetbrains.com/help/idea/gradle.html#gradle_import
+[eclipse]: https://marketplace.eclipse.org/content/buildship-gradle-integration#group-details
+[netBeans]: https://netbeans.org/features/java/build-tools.html
+[get-evaluation]: https://www.teamdev.com/jxbrowser#evaluate


### PR DESCRIPTION
This PR updates the `README.md` file to use footnote links instead in-place onces.