### PR TITLE
Make sure the `Engine` is closed

### DIFF
--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/CustomCss.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/CustomCss.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.browser.callback.InjectCssCallback;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -44,6 +46,12 @@ public final class CustomCss {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Custom CSS");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(800, 600);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/CustomProtocol.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/CustomProtocol.java
@@ -33,6 +33,8 @@ import com.teamdev.jxbrowser.net.UrlRequestJob;
 import com.teamdev.jxbrowser.net.callback.InterceptUrlRequestCallback;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
 
@@ -56,6 +58,12 @@ public final class CustomProtocol {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Custom Protocol Handler");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DefaultZoomLevel.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DefaultZoomLevel.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import com.teamdev.jxbrowser.zoom.ZoomLevel;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -44,6 +46,12 @@ public final class DefaultZoomLevel {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Change Default Zoom Level");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DisablePdfViewer.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DisablePdfViewer.java
@@ -28,6 +28,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.plugin.Plugins;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
 
@@ -61,6 +63,12 @@ public final class DisablePdfViewer {
         BrowserView view = BrowserView.newInstance(browser);
 
         JFrame frame = new JFrame("Disabling PDF Viewer");
+        frame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                browser.engine().close();
+            }
+        });
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         frame.add(view, BorderLayout.CENTER);
         frame.setSize(800, 600);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DisableZoom.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DisableZoom.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import com.teamdev.jxbrowser.zoom.ZoomLevel;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -44,6 +46,12 @@ public final class DisableZoom {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Disable Zoom");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DomForm.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DomForm.java
@@ -29,6 +29,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
 
@@ -45,6 +47,12 @@ public final class DomForm {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("DOM HTML Form");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.getContentPane().add(view, BorderLayout.CENTER);
             frame.setSize(800, 600);
@@ -59,13 +67,12 @@ public final class DomForm {
                     element.findElementByName("lastName").ifPresent(lastName ->
                             lastName.putAttribute("value", "Doe"));
                 }));
-        browser.mainFrame().ifPresent(mainFrame -> {
-            mainFrame.loadHtml("<html><body><form name=\"myForm\">" +
-                    "First name: <input type=\"text\" name=\"firstName\"/><br/>" +
-                    "Last name: <input type=\"text\" name=\"lastName\"/><br/>" +
-                    "<input type=\"button\" value=\"Save\"/>" +
-                    "</form></body></html>");
-        });
+        browser.mainFrame().ifPresent(mainFrame ->
+                mainFrame.loadHtml("<html><body><form name=\"myForm\">" +
+                        "First name: <input type=\"text\" name=\"firstName\"/><br/>" +
+                        "Last name: <input type=\"text\" name=\"lastName\"/><br/>" +
+                        "<input type=\"button\" value=\"Save\"/>" +
+                        "</form></body></html>"));
     }
 }
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DomGetAttributes.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DomGetAttributes.java
@@ -34,19 +34,18 @@ import com.teamdev.jxbrowser.frame.Frame;
 public final class DomGetAttributes {
 
     public static void main(String[] args) {
-        Engine engine = Engine.newInstance(OFF_SCREEN);
-        Browser browser = engine.newBrowser();
+        try (Engine engine = Engine.newInstance(OFF_SCREEN)) {
+            Browser browser = engine.newBrowser();
 
-        browser.mainFrame().ifPresent(mainFrame -> {
-            mainFrame.loadHtml(
-                    "<html><body><a href='#' id='link' title='link title'>Link</a></body></html>");
-        });
-        browser.mainFrame()
-                .flatMap(Frame::document)
-                .flatMap(Document::documentElement)
-                .flatMap(element -> element.findElementById("link"))
-                .ifPresent(
-                        linkElement -> linkElement.attributes().forEach(DomGetAttributes::print));
+            browser.mainFrame().ifPresent(mainFrame -> mainFrame.loadHtml(
+                    "<html><body><a href='#' id='link' title='link title'>Link</a></body></html>"));
+            browser.mainFrame()
+                    .flatMap(Frame::document)
+                    .flatMap(Document::documentElement)
+                    .flatMap(element -> element.findElementById("link"))
+                    .ifPresent(
+                            linkElement -> linkElement.attributes().forEach(DomGetAttributes::print));
+        }
     }
 
     private static void print(String name, String value) {

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DomKeyEvents.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DomKeyEvents.java
@@ -37,6 +37,8 @@ import com.teamdev.jxbrowser.frame.Frame;
 import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import javax.swing.JFrame;
@@ -60,6 +62,12 @@ public class DomKeyEvents {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("DOM Keyboard Event Listener ");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(800, 600);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DomMouseEvents.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DomMouseEvents.java
@@ -38,6 +38,8 @@ import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.ui.Point;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import javax.swing.JFrame;
@@ -61,6 +63,12 @@ public class DomMouseEvents {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("DOM Mouse Event Listener");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(800, 600);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DomQuerySelector.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DomQuerySelector.java
@@ -28,6 +28,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -45,6 +47,12 @@ public final class DomQuerySelector {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("DOM Query Selector");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.getContentPane().add(view, BorderLayout.CENTER);
             frame.setSize(800, 600);
@@ -56,13 +64,12 @@ public final class DomQuerySelector {
                 event.frame().document().flatMap(Document::documentElement).ifPresent(element ->
                         element.findElementsByCssSelector("p").forEach(paragraph ->
                                 System.out.println("innerHTML " + paragraph.innerHtml()))));
-        browser.mainFrame().ifPresent(mainFrame -> {
-            mainFrame.loadHtml("<html><body><div id='root'>" +
-                    "<p>paragraph1</p>" +
-                    "<p>paragraph2</p>" +
-                    "<p>paragraph3</p>" +
-                    "</div></body></html>");
-        });
+        browser.mainFrame().ifPresent(mainFrame ->
+                mainFrame.loadHtml("<html><body><div id='root'>" +
+                        "<p>paragraph1</p>" +
+                        "<p>paragraph2</p>" +
+                        "<p>paragraph3</p>" +
+                        "</div></body></html>"));
     }
 }
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DomSelectOption.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DomSelectOption.java
@@ -31,6 +31,8 @@ import com.teamdev.jxbrowser.frame.Frame;
 import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -48,6 +50,12 @@ public final class DomSelectOption {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("DOM Select Option");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);
@@ -63,13 +71,12 @@ public final class DomSelectOption {
                             ((OptionElement) options[2]).select();
                             System.out.println(selectElement.innerHtml());
                         }));
-        browser.mainFrame().ifPresent(mainFrame -> {
-            mainFrame.loadHtml("<html><body><select id='select-tag'>\n" +
-                    "  <option value=\"volvo\">Volvo</option>\n" +
-                    "  <option value=\"saab\">Saab</option>\n" +
-                    "  <option value=\"opel\">Opel</option>\n" +
-                    "  <option value=\"audi\">Audi</option>\n" +
-                    "</select></body></html>");
-        });
+        browser.mainFrame().ifPresent(mainFrame ->
+                mainFrame.loadHtml("<html><body><select id='select-tag'>\n" +
+                        "  <option value=\"volvo\">Volvo</option>\n" +
+                        "  <option value=\"saab\">Saab</option>\n" +
+                        "  <option value=\"opel\">Opel</option>\n" +
+                        "  <option value=\"audi\">Audi</option>\n" +
+                        "</select></body></html>"));
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DownloadFile.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DownloadFile.java
@@ -28,6 +28,8 @@ import com.teamdev.jxbrowser.download.event.DownloadFinished;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -52,6 +54,12 @@ public final class DownloadFile {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Download File");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(800, 600);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/FileUpload.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/FileUpload.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.browser.callback.OpenFileCallback;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.nio.file.Paths;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -47,6 +49,12 @@ public final class FileUpload {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("File Upload");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);
@@ -57,9 +65,8 @@ public final class FileUpload {
         browser.set(OpenFileCallback.class, (params, tell) ->
                 tell.open(Paths.get("file.txt")));
 
-        browser.mainFrame().ifPresent(mainFrame -> {
-            mainFrame.loadHtml("Please specify a file, or a set of files:<br>\n" +
-                    "<input type='file' name='datafile' size='40'>");
-        });
+        browser.mainFrame().ifPresent(mainFrame ->
+                mainFrame.loadHtml("Please specify a file, or a set of files:<br>\n" +
+                        "<input type='file' name='datafile' size='40'>"));
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/FilterCookies.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/FilterCookies.java
@@ -29,6 +29,8 @@ import com.teamdev.jxbrowser.net.callback.CanGetCookiesCallback;
 import com.teamdev.jxbrowser.net.callback.CanSetCookieCallback;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -46,6 +48,12 @@ public final class FilterCookies {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Filter Cookies");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(800, 600);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/FilterImages.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/FilterImages.java
@@ -28,6 +28,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.net.callback.BeforeUrlRequestCallback;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -48,6 +50,12 @@ public final class FilterImages {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Filter Images");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/FindText.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/FindText.java
@@ -26,6 +26,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
@@ -49,6 +51,12 @@ public final class FindText {
                             System.out.println("Matches found: " + findResult.numberOfMatches())));
 
             JFrame frame = new JFrame("Find Text");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(searchField, BorderLayout.NORTH);
             frame.add(view, BorderLayout.CENTER);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/GetHtml.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/GetHtml.java
@@ -28,6 +28,8 @@ import com.teamdev.jxbrowser.navigation.Navigation;
 import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -45,6 +47,12 @@ public final class GetHtml {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Get HTML");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/Html5Video.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/Html5Video.java
@@ -26,6 +26,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -43,6 +45,12 @@ public final class Html5Video {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("HTML5 Video");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/InterceptRequest.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/InterceptRequest.java
@@ -33,6 +33,8 @@ import com.teamdev.jxbrowser.net.UrlRequestJob;
 import com.teamdev.jxbrowser.net.callback.InterceptUrlRequestCallback;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
 
@@ -53,6 +55,12 @@ public final class InterceptRequest {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Intercept Request");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(800, 600);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/JarProtocol.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/JarProtocol.java
@@ -34,6 +34,8 @@ import com.teamdev.jxbrowser.net.UrlRequestJob;
 import com.teamdev.jxbrowser.net.callback.InterceptUrlRequestCallback;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.URL;
@@ -61,6 +63,12 @@ public final class JarProtocol {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("JAR Protocol Handler");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/JsConsoleEvents.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/JsConsoleEvents.java
@@ -28,6 +28,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.js.ConsoleMessage;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -45,6 +47,12 @@ public final class JsConsoleEvents {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("JS Console Listener");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/LoadHtml.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/LoadHtml.java
@@ -26,6 +26,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -43,6 +45,12 @@ public final class LoadHtml {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Load HTML");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);
@@ -50,8 +58,7 @@ public final class LoadHtml {
             frame.setVisible(true);
         });
 
-        browser.mainFrame().ifPresent(mainFrame -> {
-            mainFrame.loadHtml("<html><body><h1>Hello there!</h1></body></html>");
-        });
+        browser.mainFrame().ifPresent(mainFrame ->
+                mainFrame.loadHtml("<html><body><h1>Hello there!</h1></body></html>"));
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/LoadHtmlThroughInterceptRequest.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/LoadHtmlThroughInterceptRequest.java
@@ -32,6 +32,8 @@ import com.teamdev.jxbrowser.net.UrlRequestJob;
 import com.teamdev.jxbrowser.net.callback.InterceptUrlRequestCallback;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -67,6 +69,12 @@ public final class LoadHtmlThroughInterceptRequest {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Load Local Files");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/LoadUrl.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/LoadUrl.java
@@ -26,6 +26,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -44,6 +46,12 @@ public final class LoadUrl {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Load URL");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/LocalWebStorage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/LocalWebStorage.java
@@ -37,13 +37,14 @@ public final class LocalWebStorage {
     private static final String KEY = "Name";
 
     public static void main(String[] args) {
-        Engine engine = Engine.newInstance(OFF_SCREEN);
-        Browser browser = engine.newBrowser();
-        browser.navigation().loadUrlAndWait("https://www.google.com");
-        browser.mainFrame().ifPresent(frame -> {
-            frame.localStorage().putItem(KEY, "Tom");
-            System.out.println((String) frame.executeJavaScript(
-                    format("window.localStorage.getItem(\"%s\")", KEY)));
-        });
+        try (Engine engine = Engine.newInstance(OFF_SCREEN)) {
+            Browser browser = engine.newBrowser();
+            browser.navigation().loadUrlAndWait("https://www.google.com");
+            browser.mainFrame().ifPresent(frame -> {
+                frame.localStorage().putItem(KEY, "Tom");
+                System.out.println((String) frame.executeJavaScript(
+                        format("window.localStorage.getItem(\"%s\")", KEY)));
+            });
+        }
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/MuteAudio.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/MuteAudio.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.media.Audio;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -57,6 +59,12 @@ public final class MuteAudio {
             });
 
             JFrame frame = new JFrame("Mute Audio");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(muteAudioButton, BorderLayout.NORTH);
             frame.add(view, BorderLayout.CENTER);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJava.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJava.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.frame.Frame;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -49,6 +51,12 @@ public final class PrintFromJava {
             print.addActionListener(e -> browser.mainFrame().ifPresent(Frame::print));
 
             JFrame frame = new JFrame("Print From Java");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.add(print, BorderLayout.NORTH);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJavaScript.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJavaScript.java
@@ -26,6 +26,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -44,16 +46,21 @@ public final class PrintFromJavaScript {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Print From JavaScript");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);
             frame.setLocationRelativeTo(null);
             frame.setVisible(true);
 
-            browser.mainFrame().ifPresent(mainFrame -> {
-                mainFrame.loadHtml("<html><body><a href='#' onclick='window.print();'>" +
-                        "Print</a></body></html>");
-            });
+            browser.mainFrame().ifPresent(mainFrame ->
+                    mainFrame.loadHtml("<html><body><a href='#' onclick='window.print();'>" +
+                            "Print</a></body></html>"));
         });
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -42,43 +42,44 @@ import com.teamdev.jxbrowser.print.event.PrintCompleted;
 public final class PrintSettings {
 
     public static void main(String[] args) {
-        Engine engine = Engine.newInstance(HARDWARE_ACCELERATED);
-        Browser browser = engine.newBrowser();
-        browser.set(PrintCallback.class, (params, tell) -> tell.print());
-        // #docfragment "Callback"
-        browser.set(PrintHtmlCallback.class, (params, tell) -> {
-            // #docfragment "Configure settings"
-            SystemPrinter<HtmlSettings> printer = params.printers()
-                    .defaultPrinter()
-                    .orElseThrow(IllegalStateException::new);
-            PrintJob<HtmlSettings> printJob = printer.printJob();
-            printJob.settings()
-                    .header("<span style='font-size: 12px;'>Page header:</span>"
-                            + "<span class='title'></span>")
-                    .footer("<span style='font-size: 12px;'>Page footer:</span>"
-                            + "<span class='pageNumber'></span>")
-                    .paperSize(ISO_A4)
-                    .colorModel(COLOR)
-                    .enablePrintingBackgrounds()
-                    .disablePrintingHeaderFooter()
-                    .orientation(PORTRAIT)
-                    .apply();
-            // #enddocfragment "Configure settings"
-            // #docfragment "Subscribe to PrintCompleted"
-            printJob.on(PrintCompleted.class, event -> {
-                if (event.isSuccess()) {
-                    System.out.println("Printing is completed successfully.");
-                } else {
-                    System.out.println("Printing has failed.");
-                }
+        try (Engine engine = Engine.newInstance(HARDWARE_ACCELERATED)) {
+            Browser browser = engine.newBrowser();
+            browser.set(PrintCallback.class, (params, tell) -> tell.print());
+            // #docfragment "Callback"
+            browser.set(PrintHtmlCallback.class, (params, tell) -> {
+                // #docfragment "Configure settings"
+                SystemPrinter<HtmlSettings> printer = params.printers()
+                        .defaultPrinter()
+                        .orElseThrow(IllegalStateException::new);
+                PrintJob<HtmlSettings> printJob = printer.printJob();
+                printJob.settings()
+                        .header("<span style='font-size: 12px;'>Page header:</span>"
+                                + "<span class='title'></span>")
+                        .footer("<span style='font-size: 12px;'>Page footer:</span>"
+                                + "<span class='pageNumber'></span>")
+                        .paperSize(ISO_A4)
+                        .colorModel(COLOR)
+                        .enablePrintingBackgrounds()
+                        .disablePrintingHeaderFooter()
+                        .orientation(PORTRAIT)
+                        .apply();
+                // #enddocfragment "Configure settings"
+                // #docfragment "Subscribe to PrintCompleted"
+                printJob.on(PrintCompleted.class, event -> {
+                    if (event.isSuccess()) {
+                        System.out.println("Printing is completed successfully.");
+                    } else {
+                        System.out.println("Printing has failed.");
+                    }
+                });
+                // #enddocfragment "Subscribe to PrintCompleted"
+                // #docfragment "Proceed"
+                tell.proceed(printer);
+                // #enddocfragment "Proceed"
             });
-            // #enddocfragment "Subscribe to PrintCompleted"
-            // #docfragment "Proceed"
-            tell.proceed(printer);
-            // #enddocfragment "Proceed"
-        });
-        // #enddocfragment "Callback"
-        browser.navigation().loadUrlAndWait("https://google.com");
-        browser.mainFrame().ifPresent(Frame::print);
+            // #enddocfragment "Callback"
+            browser.navigation().loadUrlAndWait("https://google.com");
+            browser.mainFrame().ifPresent(Frame::print);
+        }
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
@@ -42,28 +42,29 @@ import java.nio.file.Paths;
 public final class PrintToPdf {
 
     public static void main(String[] args) {
-        Engine engine = Engine.newInstance(OFF_SCREEN);
-        Browser browser = engine.newBrowser();
-        browser.set(PrintCallback.class, (params, tell) -> tell.print());
-        browser.set(PrintHtmlCallback.class, (params, tell) -> {
-            PdfPrinter<PdfPrinter.HtmlSettings> pdfPrinter =
-                    params.printers().pdfPrinter();
-            PrintJob<HtmlSettings> printJob = pdfPrinter.printJob();
-            printJob.settings()
-                    .pdfFilePath(Paths.get("google.pdf").toAbsolutePath())
-                    .enablePrintingBackgrounds()
-                    .orientation(PORTRAIT)
-                    .apply();
-            printJob.on(PrintCompleted.class, event -> {
-                if (event.isSuccess()) {
-                    System.out.println("Printing is completed successfully.");
-                } else {
-                    System.out.println("Printing has failed.");
-                }
+        try (Engine engine = Engine.newInstance(OFF_SCREEN)) {
+            Browser browser = engine.newBrowser();
+            browser.set(PrintCallback.class, (params, tell) -> tell.print());
+            browser.set(PrintHtmlCallback.class, (params, tell) -> {
+                PdfPrinter<PdfPrinter.HtmlSettings> pdfPrinter =
+                        params.printers().pdfPrinter();
+                PrintJob<HtmlSettings> printJob = pdfPrinter.printJob();
+                printJob.settings()
+                        .pdfFilePath(Paths.get("google.pdf").toAbsolutePath())
+                        .enablePrintingBackgrounds()
+                        .orientation(PORTRAIT)
+                        .apply();
+                printJob.on(PrintCompleted.class, event -> {
+                    if (event.isSuccess()) {
+                        System.out.println("Printing is completed successfully.");
+                    } else {
+                        System.out.println("Printing has failed.");
+                    }
+                });
+                tell.proceed(pdfPrinter);
             });
-            tell.proceed(pdfPrinter);
-        });
-        browser.navigation().loadUrlAndWait("https://google.com");
-        browser.mainFrame().ifPresent(Frame::print);
+            browser.navigation().loadUrlAndWait("https://google.com");
+            browser.mainFrame().ifPresent(Frame::print);
+        }
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/RedirectLoggingToFile.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/RedirectLoggingToFile.java
@@ -22,16 +22,10 @@ package com.teamdev.jxbrowser.examples;
 
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
 
-import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
-import com.teamdev.jxbrowser.view.swing.BrowserView;
-import java.awt.BorderLayout;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
 
 /**
  * This example demonstrates how to redirect all JxBrowser log messages to the '*.log' file.
@@ -54,19 +48,6 @@ public final class RedirectLoggingToFile {
         System.out.println("Log file path: " + loggingFile.toAbsolutePath());
 
         Engine engine = Engine.newInstance(HARDWARE_ACCELERATED);
-        Browser browser = engine.newBrowser();
-
-        SwingUtilities.invokeLater(() -> {
-            BrowserView view = BrowserView.newInstance(browser);
-
-            JFrame frame = new JFrame("Redirect Logging To File");
-            frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-            frame.add(view, BorderLayout.CENTER);
-            frame.setSize(700, 500);
-            frame.setLocationRelativeTo(null);
-            frame.setVisible(true);
-        });
-
-        browser.navigation().loadUrl("https://www.google.com");
+        engine.close();
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SaveWebPage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SaveWebPage.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.browser.SavePageType;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import javax.swing.JFrame;
@@ -46,6 +48,12 @@ public final class SaveWebPage {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Save Web Page");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SelectClientCertificate.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SelectClientCertificate.java
@@ -32,6 +32,8 @@ import com.teamdev.jxbrowser.net.tls.SslPrivateKey;
 import com.teamdev.jxbrowser.net.tls.X509Certificates;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
@@ -48,7 +50,8 @@ import javax.swing.WindowConstants;
  * must select a required SSL certificate to continue loading web page.
  *
  * <p>Important: before you run this example, please follow the instruction at
- * https://badssl.com/download/ and install the required custom SSL certificate.
+ * <a href="https://badssl.com/download/">https://badssl.com/download/</a>
+ * and install the required custom SSL certificate.
  */
 public final class SelectClientCertificate {
 
@@ -64,6 +67,12 @@ public final class SelectClientCertificate {
             view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Select Client SSL Certificate");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SelectionAsHtml.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SelectionAsHtml.java
@@ -26,6 +26,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -51,6 +53,12 @@ public final class SelectionAsHtml {
                                     "Selected HTML", JOptionPane.PLAIN_MESSAGE))));
 
             JFrame frame = new JFrame("Get Selected HTML");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(button, BorderLayout.NORTH);
             frame.add(view, BorderLayout.CENTER);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SpellCheckEvents.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SpellCheckEvents.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.browser.event.SpellCheckCompleted;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -45,6 +47,12 @@ public final class SpellCheckEvents {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Spell Check Events");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SpellCheckSuggestions.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SpellCheckSuggestions.java
@@ -30,6 +30,8 @@ import com.teamdev.jxbrowser.spellcheck.Dictionary;
 import com.teamdev.jxbrowser.ui.Point;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.List;
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
@@ -58,6 +60,12 @@ public final class SpellCheckSuggestions {
             view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Spell Check Suggestions");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);
@@ -100,10 +108,9 @@ public final class SpellCheckSuggestions {
             Point location = params.location();
             popupMenu.show(view, location.x(), location.y());
         });
-        browser.mainFrame().ifPresent(mainFrame -> {
-            mainFrame.loadHtml("<html><body><textarea rows='20' cols='30'>" +
-                    "Smple text with mitake.</textarea></body></html>");
-        });
+        browser.mainFrame().ifPresent(mainFrame ->
+                mainFrame.loadHtml("<html><body><textarea rows='20' cols='30'>" +
+                        "Smple text with mitake.</textarea></body></html>"));
 
     }
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SslCertificateError.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SslCertificateError.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.engine.EngineOptions;
 import com.teamdev.jxbrowser.engine.RenderingMode;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -46,6 +48,12 @@ public final class SslCertificateError {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Ignore SSL Certificate Errors");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SslCertificateVerifier.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SslCertificateVerifier.java
@@ -29,6 +29,8 @@ import com.teamdev.jxbrowser.net.callback.VerifyCertificateCallback;
 import com.teamdev.jxbrowser.net.callback.VerifyCertificateCallback.Response;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -47,6 +49,12 @@ public final class SslCertificateVerifier {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("SSL Certificate Verifier");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SuppressKey.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SuppressKey.java
@@ -28,6 +28,8 @@ import com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -58,6 +60,12 @@ public final class SuppressKey {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Suppress the Key Pressed event");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(500, 400);
@@ -65,8 +73,6 @@ public final class SuppressKey {
             frame.setVisible(true);
         });
 
-        browser.mainFrame().ifPresent(mainFrame -> {
-            mainFrame.loadHtml("<textarea></textarea>");
-        });
+        browser.mainFrame().ifPresent(mainFrame -> mainFrame.loadHtml("<textarea></textarea>"));
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SuppressMouse.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SuppressMouse.java
@@ -27,13 +27,15 @@ import com.teamdev.jxbrowser.browser.callback.input.PressMouseCallback;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to suppress {@code MousePressed} event using {@code
- * PressMouseCallback}.
+ * This example demonstrates how to suppress {@code MousePressed} event using
+ * {@code PressMouseCallback}.
  *
  * <p>For suppressing other mouse events the following callbacks are used:
  * <li>{@code EnterMouseCallback}</li>
@@ -60,6 +62,12 @@ public final class SuppressMouse {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Suppress the Mouse Pressed event");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(500, 400);
@@ -67,10 +75,8 @@ public final class SuppressMouse {
             frame.setVisible(true);
         });
 
-        browser.mainFrame().ifPresent(mainFrame -> {
-            mainFrame.loadHtml(
-                    "<button onclick=\"clicked()\">click holding shift</button>" +
-                            "<script>function clicked() {alert('clicked');}</script>");
-        });
+        browser.mainFrame().ifPresent(mainFrame ->
+                mainFrame.loadHtml("<button onclick=\"clicked()\">click holding shift</button>" +
+                        "<script>function clicked() {alert('clicked');}</script>"));
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.engine.EngineOptions;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -47,6 +49,12 @@ public final class UserAgent {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("User Agent");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/VoiceRecognition.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/VoiceRecognition.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.engine.EngineOptions;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -37,8 +39,8 @@ import javax.swing.WindowConstants;
  * <p>By default, voice recognition functionality is disabled. To enable it you must
  * provide your Google API Keys to the Chromium engine as shown in this example.
  *
- * <p>The instruction that describes how to acquire the API keys you can find at
- * https://www.chromium.org/developers/how-tos/api-keys
+ * <p>The instruction that describes how to acquire the API keys can be found
+ * <a href="https://www.chromium.org/developers/how-tos/api-keys">here</a>.
  */
 public final class VoiceRecognition {
 
@@ -55,6 +57,12 @@ public final class VoiceRecognition {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Voice Recognition");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/WebSocket.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/WebSocket.java
@@ -26,6 +26,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -44,6 +46,12 @@ public final class WebSocket {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Web Socket");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(800, 600);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/XPath.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/XPath.java
@@ -29,10 +29,6 @@ import com.teamdev.jxbrowser.dom.XPathResult;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.navigation.Navigation;
 import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
-import com.teamdev.jxbrowser.view.swing.BrowserView;
-import java.awt.BorderLayout;
-import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
 
 /**
  * This example demonstrates how to evaluate the XPath expression and work with the result.
@@ -40,32 +36,21 @@ import javax.swing.SwingUtilities;
 public final class XPath {
 
     public static void main(String[] args) {
-        Engine engine = Engine.newInstance(OFF_SCREEN);
-        Browser browser = engine.newBrowser();
-
-        SwingUtilities.invokeLater(() -> {
-            BrowserView view = BrowserView.newInstance(browser);
-
-            JFrame frame = new JFrame("Evaluate XPath");
-            frame.getContentPane().add(view, BorderLayout.CENTER);
-            frame.setSize(800, 600);
-            frame.setLocationRelativeTo(null);
-            frame.setVisible(true);
-        });
-
-        Navigation navigation = browser.navigation();
-        navigation.on(FrameLoadFinished.class, event ->
-                event.frame().document().flatMap(Document::documentElement).ifPresent(element -> {
-                    try {
-                        XPathResult result = element.evaluate("count(//div)");
-                        if (result.isNumber()) {
-                            System.out.println("Result: " + result.asNumber());
+        try (Engine engine = Engine.newInstance(OFF_SCREEN)) {
+            Browser browser = engine.newBrowser();
+            Navigation navigation = browser.navigation();
+            navigation.on(FrameLoadFinished.class, event ->
+                    event.frame().document().flatMap(Document::documentElement).ifPresent(element -> {
+                        try {
+                            XPathResult result = element.evaluate("count(//div)");
+                            if (result.isNumber()) {
+                                System.out.println("Result: " + result.asNumber());
+                            }
+                        } catch (XPathException e) {
+                            System.out.println(e.getMessage());
                         }
-                    } catch (XPathException e) {
-                        System.out.println(e.getMessage());
-                    }
-                }));
-
-        navigation.loadUrl("https://www.teamdev.com/jxbrowser");
+                    }));
+            navigation.loadUrl("https://www.teamdev.com/jxbrowser");
+        }
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/ZoomLevel.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/ZoomLevel.java
@@ -30,6 +30,8 @@ import com.teamdev.jxbrowser.view.swing.BrowserView;
 import com.teamdev.jxbrowser.zoom.ZoomLevels;
 import com.teamdev.jxbrowser.zoom.event.ZoomLevelChanged;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -52,6 +54,12 @@ public final class ZoomLevel {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Change Zoom Level");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInJFxPanel.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInJFxPanel.java
@@ -26,6 +26,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.javafx.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.Scene;
@@ -34,8 +36,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to embed JavaFX BrowserView into Swing/AWT window using {@link
- * JFXPanel}.
+ * This example demonstrates how to embed JavaFX BrowserView into Swing/AWT window using
+ * {@link JFXPanel}.
  */
 public final class BrowserViewInJFxPanel {
 
@@ -51,11 +53,16 @@ public final class BrowserViewInJFxPanel {
 
         SwingUtilities.invokeLater(() -> {
             JFrame frame = new JFrame("JavaFX BrowserView in Swing app");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(panel, BorderLayout.CENTER);
             frame.setSize(700, 500);
             frame.setLocationRelativeTo(null);
-            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
             frame.setVisible(true);
         });
         browser.navigation().loadUrl("https://www.google.com");

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInTabPane.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInTabPane.java
@@ -77,5 +77,7 @@ public final class BrowserViewInTabPane extends Application {
         primaryStage.setTitle("Browser View In Tab Pane");
         primaryStage.setScene(scene);
         primaryStage.show();
+
+        primaryStage.setOnCloseRequest(event -> engine.close());
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/FxmlBrowserView.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/FxmlBrowserView.java
@@ -40,9 +40,10 @@ public final class FxmlBrowserView extends StackPane {
      * Constructs an instance of {@code FxmlBrowserView}.
      */
     public FxmlBrowserView() {
-        Engine engine = Engine.newInstance(HARDWARE_ACCELERATED);
-        view = BrowserView.newInstance(engine.newBrowser());
-        getChildren().add(view);
+        try (Engine engine = Engine.newInstance(HARDWARE_ACCELERATED)) {
+            view = BrowserView.newInstance(engine.newBrowser());
+            getChildren().add(view);
+        }
     }
 
     /**

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/FxmlBrowserViewController.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/FxmlBrowserViewController.java
@@ -20,6 +20,7 @@
 
 package com.teamdev.jxbrowser.examples.javafx;
 
+import com.teamdev.jxbrowser.browser.Browser;
 import java.net.URL;
 import java.util.ResourceBundle;
 import javafx.event.ActionEvent;
@@ -41,10 +42,14 @@ public final class FxmlBrowserViewController implements Initializable {
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
-        browserView.browser().navigation().loadUrl(textField.getText());
+        try (Browser browser = browserView.browser()) {
+            browser.navigation().loadUrl(textField.getText());
+        }
     }
 
     public void loadUrl(ActionEvent actionEvent) {
-        browserView.browser().navigation().loadUrl(textField.getText());
+        try (Browser browser = browserView.browser()) {
+            browser.navigation().loadUrl(textField.getText());
+        }
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/JavaFxBrowserView.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/JavaFxBrowserView.java
@@ -52,5 +52,6 @@ public final class JavaFxBrowserView extends Application {
         primaryStage.show();
 
         browser.navigation().loadUrl("https://www.google.com");
+        primaryStage.setOnCloseRequest(event -> engine.close());
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/AuthenticationDialog.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/AuthenticationDialog.java
@@ -31,6 +31,8 @@ import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
 import java.awt.Frame;
 import java.awt.GridLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -55,6 +57,12 @@ public final class AuthenticationDialog {
 
             JFrame frame = new JFrame("Hello World");
             engine.network().set(AuthenticateCallback.class, createAuthenticationPopup(frame));
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(DISPOSE_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(800, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJInternalFrame.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJInternalFrame.java
@@ -31,6 +31,8 @@ import javax.swing.JFrame;
 import javax.swing.JInternalFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
+import javax.swing.event.InternalFrameAdapter;
+import javax.swing.event.InternalFrameEvent;
 
 /**
  * This example demonstrates how to display Swing BrowserView in JInternalFrame.
@@ -65,6 +67,12 @@ public final class BrowserViewInJInternalFrame {
         BrowserView view = BrowserView.newInstance(browser);
 
         JInternalFrame frame = new JInternalFrame(title, true);
+        frame.addInternalFrameListener(new InternalFrameAdapter() {
+            @Override
+            public void internalFrameClosing(InternalFrameEvent e) {
+                engine.close();
+            }
+        });
         frame.setContentPane(view);
         frame.setLocation(100 + offset, 100 + offset);
         frame.setSize(400, 400);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJTabbedPane.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJTabbedPane.java
@@ -26,6 +26,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingUtilities;
@@ -47,6 +49,12 @@ public final class BrowserViewInJTabbedPane {
             pane.addTab("TeamDev", BrowserView.newInstance(browserTwo));
 
             JFrame frame = new JFrame("Browser View In JTabbed Pane");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.getContentPane().add(pane, BorderLayout.CENTER);
             frame.setSize(800, 600);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/CustomContextMenu.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/CustomContextMenu.java
@@ -34,6 +34,8 @@ import com.teamdev.jxbrowser.ui.Point;
 import com.teamdev.jxbrowser.ui.event.internal.rpc.MoveMouseWheel;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
@@ -56,6 +58,12 @@ public final class CustomContextMenu {
             browser.set(ShowContextMenuCallback.class, new ShowCustomContextMenu(view));
 
             JFrame frame = new JFrame("JxBrowser: Swing Context Menu");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(900, 700);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/SwingBrowserView.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/SwingBrowserView.java
@@ -27,6 +27,8 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.WindowConstants;
 
@@ -43,6 +45,12 @@ public final class SwingBrowserView {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Swing BrowserView");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/SwingFullScreen.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/SwingFullScreen.java
@@ -30,6 +30,8 @@ import com.teamdev.jxbrowser.fullscreen.event.FullScreenExited;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
 import java.awt.Frame;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
@@ -47,6 +49,12 @@ public final class SwingFullScreen {
             BrowserView view = BrowserView.newInstance(browser);
 
             JFrame frame = new JFrame("Swing Full Screen Mode");
+            frame.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    engine.close();
+                }
+            });
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
             frame.add(view, BorderLayout.CENTER);
             frame.setSize(700, 500);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/DefaultOpenPopupCallback.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/DefaultOpenPopupCallback.java
@@ -44,8 +44,7 @@ public final class DefaultOpenPopupCallback implements OpenPopupCallback {
 
     @Override
     public Response on(Params params) {
-        Browser browser = params.popupBrowser();
-        try {
+        try (Browser browser = params.popupBrowser()) {
             Display display = Display.getDefault();
             display.asyncExec(() -> {
                 Shell shell = new Shell(display);


### PR DESCRIPTION
Fixes https://github.com/TeamDev-IP/JxBrowser/issues/4074

In this changeset, we close the `Engine` in all examples. If there is no UI in the example, we use `try-with-resources`, if there is UI - we close the `Engine` when the window is closed.