### PR TITLE
Fix the plugin's version

### DIFF
--- a/tutorials/selenium/target-app/build.gradle.kts
+++ b/tutorials/selenium/target-app/build.gradle.kts
@@ -19,7 +19,7 @@
  */
 
 plugins {
-    id("edu.sc.seis.launch4j") version "2.4.9"
+    id("edu.sc.seis.launch4j") version "3.0.4"
 }
 
 launch4j {


### PR DESCRIPTION
After the recent Gradle update to 8.2.1, the `launch4j` 2.4.9 stopped being compatible with it.  We should update it.