### PR TITLE
Release JxBrowser 7.35

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     id("com.teamdev.jxbrowser.gradle") version "0.0.3"
 }
 
-val jxBrowserVersion by extra { "7.34.1" } // The version of JxBrowser used in the examples.
+val jxBrowserVersion by extra { "7.35" } // The version of JxBrowser used in the examples.
 val guavaVersion by extra { "29.0-jre" } // Some of the examples use Guava.
 
 allprojects {


### PR DESCRIPTION
Bump JxBrowser version to 7.35

In this changeset, we: 

 * Change version in: build.gradle.kts.