### PR TITLE
Release JxBrowser 7.37.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     id("com.teamdev.jxbrowser") version "1.0.1"
 }
 
-val jxBrowserVersion by extra { "7.37.1" } // The version of JxBrowser used in the examples.
+val jxBrowserVersion by extra { "7.37.2" } // The version of JxBrowser used in the examples.
 val guavaVersion by extra { "29.0-jre" } // Some of the examples use Guava.
 
 allprojects {


### PR DESCRIPTION
Bump JxBrowser version to 7.37.2

In this changeset, we: 

 * Change version in: build.gradle.kts.

Issue: https://github.com/TeamDev-IP/JxBrowser-Docs/issues/767