### PR TITLE
Add examples for Compose

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v3
         with:
-          distribution: 'corretto'
-          java-version: '8'
+          java-version: 17
+          distribution: corretto
       - run: |-
           ./gradlew build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: corretto
+          distribution: zulu
+          java-package: jdk+fx
       - run: |-
           ./gradlew build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 17
-          distribution: zulu
-          java-package: jdk+fx
+          distribution: oracle
       - run: |-
           ./gradlew build

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="RIGHT_MARGIN" value="100" />
+    <option name="RIGHT_MARGIN" value="80" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -22,6 +22,7 @@
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="SOFT_MARGINS" value="80" />
     <JavaCodeStyleSettings>
       <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
       <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -22,7 +22,6 @@
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
-    <option name="SOFT_MARGINS" value="80" />
     <JavaCodeStyleSettings>
       <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
       <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -45,6 +45,9 @@
       <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
       <option name="JD_KEEP_EMPTY_RETURN" value="false" />
     </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>
       <option name="RIGHT_MARGIN" value="72" />
     </MarkdownNavigatorCodeStyleSettings>
@@ -763,6 +766,9 @@
           </section>
         </rules>
       </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>
     <codeStyleSettings language="protobuf">
       <option name="RIGHT_MARGIN" value="80" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -9,6 +9,23 @@
       <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
       <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
     </inspection_tool>
+    <inspection_tool class="ConstantValue" enabled="true" level="TYPO" enabled_by_default="true">
+      <scope name="Production" level="WARNING" enabled="true" />
+    </inspection_tool>
+    <inspection_tool class="DataFlowIssue" enabled="true" level="TYPO" enabled_by_default="true">
+      <scope name="Production" level="WARNING" enabled="true">
+        <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
+        <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
+      </scope>
+      <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
+      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
+    </inspection_tool>
+    <inspection_tool class="FunctionName" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="namePattern" value="[A-Za-z\d]*" />
+    </inspection_tool>
+    <inspection_tool class="OptionalOfNullableMisuse" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Production" level="WARNING" enabled="true" />
+    </inspection_tool>
     <inspection_tool class="UnnecessaryLocalVariable" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreImmediatelyReturnedVariables" value="true" />
       <option name="m_ignoreAnnotatedVariables" value="false" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,8 +22,12 @@ plugins {
     java
     kotlin("jvm") version "1.9.23"
 
-    id("com.teamdev.jxbrowser") version "1.0.2" // Adds JxBrowser to the project.
-    id("org.jetbrains.compose") version "1.6.1" // Adds Compose Desktop.
+    // Adds JxBrowser.
+    id("com.teamdev.jxbrowser") version "1.0.2"
+
+    // Adds UI toolkits.
+    id("org.openjfx.javafxplugin") version "0.1.0"
+    id("org.jetbrains.compose") version "1.6.1"
 }
 
 val jxBrowserVersion by extra { "8.0.0-eap.1" } // The version of JxBrowser used in the examples.
@@ -38,6 +42,7 @@ subprojects {
     apply(plugin = "java")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "com.teamdev.jxbrowser")
+    apply(plugin = "org.openjfx.javafxplugin")
     apply(plugin = "org.jetbrains.compose")
 
     repositories {
@@ -53,6 +58,11 @@ subprojects {
     jxbrowser {
         version = jxBrowserVersion
         includePreviewBuilds = true // Until JxBrowser 8 is released.
+    }
+
+    javafx {
+        version = "17"
+        modules = listOf("javafx.controls", "javafx.swing", "javafx.fxml")
     }
 
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,20 +18,16 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-}
-
 plugins {
     java
+    kotlin("jvm") version "1.9.23"
+    id("org.jetbrains.compose") version "1.6.1"
 
     // Provides convenience methods for adding JxBrowser dependencies into a project.
-    id("com.teamdev.jxbrowser") version "1.0.1"
+    id("com.teamdev.jxbrowser") version "1.0.2"
 }
 
-val jxBrowserVersion by extra { "7.38.0" } // The version of JxBrowser used in the examples.
+val jxBrowserVersion by extra { "8.0.0-eap.1" } // The version of JxBrowser used in the examples.
 val guavaVersion by extra { "29.0-jre" } // Some of the examples use Guava.
 
 allprojects {
@@ -42,16 +38,20 @@ allprojects {
 subprojects {
     apply(plugin = "java")
     apply(plugin = "com.teamdev.jxbrowser")
+    apply(plugin = "org.jetbrains.kotlin.jvm")
+    apply(plugin = "org.jetbrains.compose")
 
-    java.sourceCompatibility = JavaVersion.VERSION_1_8
-    java.targetCompatibility = JavaVersion.VERSION_1_8
+    java.sourceCompatibility = JavaVersion.VERSION_17
+    java.targetCompatibility = JavaVersion.VERSION_17
 
     repositories {
         mavenCentral()
+        google()
     }
 
     jxbrowser {
         version = jxBrowserVersion
+        includePreviewBuilds = true
     }
 
     dependencies {
@@ -88,6 +88,12 @@ subprojects {
         // JxBrowser for Swing dependency.
         implementation(jxbrowser.swing)
 
+        // JxBrowser for Compose dependency.
+        implementation(jxbrowser.compose)
+
+        // Dependency on Compose for the current platform.
+        implementation(compose.desktop.currentOs)
+
         // JxBrowser for SWT dependency.
         implementation(jxbrowser.swt)
 
@@ -96,8 +102,6 @@ subprojects {
 
         // Depend on Guava for the Resources utility class used for loading resource files into strings.
         implementation("com.google.guava:guava:$guavaVersion")
-
-        implementation(files("$rootDir/examples/src/main/resources/resource.jar"))
     }
 
     tasks.withType<JavaExec> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,11 +19,11 @@
  */
 
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.9.23"
-    id("org.jetbrains.compose") version "1.6.1"
+    java
+    kotlin("jvm") version "1.9.23"
 
-    // Provides convenience methods for adding JxBrowser dependencies into a project.
-    id("com.teamdev.jxbrowser") version "1.0.2"
+    id("com.teamdev.jxbrowser") version "1.0.2" // Adds JxBrowser to the project.
+    id("org.jetbrains.compose") version "1.6.1" // Adds Compose Desktop.
 }
 
 val jxBrowserVersion by extra { "8.0.0-eap.1" } // The version of JxBrowser used in the examples.
@@ -35,9 +35,10 @@ allprojects {
 }
 
 subprojects {
+    apply(plugin = "java")
     apply(plugin = "org.jetbrains.kotlin.jvm")
-    apply(plugin = "org.jetbrains.compose")
     apply(plugin = "com.teamdev.jxbrowser")
+    apply(plugin = "org.jetbrains.compose")
 
     repositories {
         mavenCentral()
@@ -51,7 +52,7 @@ subprojects {
 
     jxbrowser {
         version = jxBrowserVersion
-        includePreviewBuilds = true
+        includePreviewBuilds = true // Until JxBrowser 8 is released.
     }
 
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,7 @@
  */
 
 plugins {
-    java
-    kotlin("jvm") version "1.9.23"
+    id("org.jetbrains.kotlin.jvm") version "1.9.23"
     id("org.jetbrains.compose") version "1.6.1"
 
     // Provides convenience methods for adding JxBrowser dependencies into a project.
@@ -36,17 +35,18 @@ allprojects {
 }
 
 subprojects {
-    apply(plugin = "java")
-    apply(plugin = "com.teamdev.jxbrowser")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jetbrains.compose")
-
-    java.sourceCompatibility = JavaVersion.VERSION_17
-    java.targetCompatibility = JavaVersion.VERSION_17
+    apply(plugin = "com.teamdev.jxbrowser")
 
     repositories {
         mavenCentral()
         google()
+    }
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     jxbrowser {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,7 @@ subprojects {
         // JxBrowser for SWT dependency.
         implementation(jxbrowser.swt)
 
-        // Dependency on a SWT for the current platform.
+        // Dependency on an SWT for the current platform.
         implementation(Swt.toolkitDependency)
 
         // Depend on Guava for the Resources utility class used for loading resource files into strings.

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
@@ -28,8 +28,8 @@ import java.io.File
 import javax.imageio.ImageIO
 
 /**
- * This example demonstrates how to take bitmap of the loaded web page,
- * convert it to a Java AWT image and save it to a PNG file.
+ * This example demonstrates how to take a bitmap of the loaded web page,
+ * convert it to a Java AWT image and save to a PNG file.
  */
 fun main() {
     val engine = Engine(RenderingMode.OFF_SCREEN)

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
@@ -29,7 +29,7 @@ import javax.imageio.ImageIO
 
 /**
  * This example demonstrates how to take a bitmap of the loaded web page,
- * convert it to a Java AWT image and save to a PNG file.
+ * convert it to a Java AWT image, and save to a PNG file.
  */
 fun main() {
     val engine = Engine(RenderingMode.OFF_SCREEN)

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2024, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.teamdev.jxbrowser.examples.compose
+
+import com.teamdev.jxbrowser.compose.graphics.toBufferedImage
+import com.teamdev.jxbrowser.dsl.Engine
+import com.teamdev.jxbrowser.dsl.browser.navigation
+import com.teamdev.jxbrowser.engine.RenderingMode
+import java.io.File
+import javax.imageio.ImageIO
+
+/**
+ * This example demonstrates how to take bitmap of the loaded web page,
+ * convert it to a Java AWT image and save it to a PNG file.
+ */
+fun main() {
+    val engine = Engine(RenderingMode.OFF_SCREEN)
+    val browser = engine.newBrowser().apply { resize(1024, 768) }
+    browser.navigation.loadUrlAndWait("https://google.com/")
+
+    // Get `Bitmap` with the image of the currently loaded web page.
+    val bitmap = browser.bitmap()
+
+    // Convert the bitmap to `java.awt.image.BufferedImage`.
+    val image = bitmap.toBufferedImage()
+
+    // Save the image to a PNG file.
+    ImageIO.write(image, "PNG", File("bitmap.png"))
+
+    // Close the engine and release all resources.
+    engine.close()
+}

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/ComposeBrowserView.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/ComposeBrowserView.kt
@@ -30,7 +30,7 @@ import com.teamdev.jxbrowser.engine.RenderingMode
 
 /**
  * This example demonstrates how to embed Compose [BrowserView]
- * into Compose application.
+ * into a Compose application.
  */
 fun main(): Unit = singleWindowApplication(title = "Compose Browser View") {
     val engine = remember { Engine(RenderingMode.OFF_SCREEN) }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/ComposeBrowserView.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/ComposeBrowserView.kt
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2024, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.teamdev.jxbrowser.examples.compose
+
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.window.singleWindowApplication
+import com.teamdev.jxbrowser.compose.BrowserView
+import com.teamdev.jxbrowser.dsl.Engine
+import com.teamdev.jxbrowser.dsl.browser.navigation
+import com.teamdev.jxbrowser.engine.RenderingMode
+
+/**
+ * This example demonstrates how to embed Compose [BrowserView]
+ * into Compose application.
+ */
+fun main(): Unit = singleWindowApplication {
+    val engine = remember { Engine(RenderingMode.OFF_SCREEN) }
+    val browser = remember { engine.newBrowser() }
+    BrowserView(browser)
+    DisposableEffect(Unit) {
+        browser.navigation.loadUrl("https://google.com/")
+        onDispose {
+            engine.close()
+        }
+    }
+}

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/ComposeBrowserView.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/ComposeBrowserView.kt
@@ -32,7 +32,7 @@ import com.teamdev.jxbrowser.engine.RenderingMode
  * This example demonstrates how to embed Compose [BrowserView]
  * into Compose application.
  */
-fun main(): Unit = singleWindowApplication {
+fun main(): Unit = singleWindowApplication(title = "Compose Browser View") {
     val engine = remember { Engine(RenderingMode.OFF_SCREEN) }
     val browser = remember { engine.newBrowser() }
     BrowserView(browser)

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2024, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.teamdev.jxbrowser.examples.compose
+
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.singleWindowApplication
+import com.teamdev.jxbrowser.browser.callback.ShowContextMenuCallback
+import com.teamdev.jxbrowser.compose.BrowserView
+import com.teamdev.jxbrowser.dsl.Engine
+import com.teamdev.jxbrowser.dsl.browser.mainFrame
+import com.teamdev.jxbrowser.dsl.browser.navigation
+import com.teamdev.jxbrowser.dsl.register
+import com.teamdev.jxbrowser.dsl.removeCallback
+import com.teamdev.jxbrowser.engine.RenderingMode
+
+/**
+ * This example demonstrates how to build a custom context menu using
+ * Compose API and browser's [ShowContextMenuCallback].
+ *
+ * The browser uses this callback when a user right-clicks on a web page.
+ */
+fun main() = singleWindowApplication {
+    val engine = remember { Engine(RenderingMode.OFF_SCREEN) }
+    val browser = remember { engine.newBrowser() }
+
+    // Store context menu state.
+    var menuShowed by remember { mutableStateOf(false) }
+    var menuLocation by remember { mutableStateOf(DpOffset.Zero) }
+    val clipboard = LocalClipboardManager.current
+
+    // Add browser view.
+    BrowserView(browser)
+
+    // Add custom context menu.
+    DropdownMenu(
+        expanded = menuShowed,
+        offset = menuLocation,
+        onDismissRequest = { menuShowed = false },
+    ) {
+        DropdownMenuItem(onClick = {
+            val selectedText = browser.mainFrame?.selectionAsText()!!
+            clipboard.setText(AnnotatedString(selectedText))
+            menuShowed = false
+        }
+        ) {
+            Text("Copy")
+        }
+        DropdownMenuItem(onClick = {
+            browser.navigation.goBack()
+            menuShowed = false
+        }) {
+            Text("Back")
+        }
+        DropdownMenuItem(onClick = {
+            browser.navigation.goForward()
+            menuShowed = false
+        }) {
+            Text("Forward")
+        }
+        DropdownMenuItem(onClick = {
+            browser.navigation.reload()
+            menuShowed = false
+        }) {
+            Text("Reload")
+        }
+    }
+
+    DisposableEffect(Unit) {
+
+        // Register a callback, which triggers showing of the menu.
+        browser.register(ShowContextMenuCallback { params, action ->
+            menuLocation = with(params.location()) { DpOffset(x().dp, y().dp) }
+            menuShowed = true
+            action.close()
+        })
+
+        browser.navigation().loadUrl("teamdev.com/jxbrowser")
+
+        // The callback can be removed  when it is no longer needed.
+        onDispose {
+            browser.removeCallback<ShowContextMenuCallback>()
+            engine.close()
+        }
+    }
+}

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
@@ -95,8 +95,8 @@ fun main() = singleWindowApplication(title = "Custom Context Menu") {
 
     DisposableEffect(Unit) {
 
-        // Register a callback, which shows the menu when a user right-clicks
-        // on a web page
+        // Register a callback to display the menu
+        // upon right-clicking on a web page.
         browser.register(ShowContextMenuCallback { params, action ->
             menuLocation = with(params.location()) { DpOffset(x().dp, y().dp) }
             menuShowed = true

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
@@ -47,7 +47,7 @@ import com.teamdev.jxbrowser.engine.RenderingMode
  * We are going to create our own [DropdownMenu] and bind it to the browser
  * with the callback.
  */
-fun main() = singleWindowApplication {
+fun main() = singleWindowApplication(title = "Custom Context Menu") {
     val engine = remember { Engine(RenderingMode.OFF_SCREEN) }
     val browser = remember { engine.newBrowser() }
 

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.singleWindowApplication
+import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.browser.callback.ShowContextMenuCallback
 import com.teamdev.jxbrowser.compose.BrowserView
 import com.teamdev.jxbrowser.dsl.Engine
@@ -40,15 +41,17 @@ import com.teamdev.jxbrowser.engine.RenderingMode
 
 /**
  * This example demonstrates how to build a custom context menu using
- * Compose API and browser's [ShowContextMenuCallback].
+ * [ShowContextMenuCallback] and Compose API.
  *
- * The browser uses this callback when a user right-clicks on a web page.
+ * [Browser] invokes this callback when a user right-clicks on a web page.
+ * We are going to create our own [DropdownMenu] and bind it to the browser
+ * with the callback.
  */
 fun main() = singleWindowApplication {
     val engine = remember { Engine(RenderingMode.OFF_SCREEN) }
     val browser = remember { engine.newBrowser() }
 
-    // Store context menu state.
+    // Store dropdown menu state.
     var menuShowed by remember { mutableStateOf(false) }
     var menuLocation by remember { mutableStateOf(DpOffset.Zero) }
     val clipboard = LocalClipboardManager.current
@@ -58,7 +61,7 @@ fun main() = singleWindowApplication {
 
     // Add custom context menu.
     DropdownMenu(
-        expanded = menuShowed,
+        expanded = menuShowed, // Controls menu's visibility.
         offset = menuLocation,
         onDismissRequest = { menuShowed = false },
     ) {
@@ -92,7 +95,8 @@ fun main() = singleWindowApplication {
 
     DisposableEffect(Unit) {
 
-        // Register a callback, which triggers showing of the menu.
+        // Register a callback, which shows the menu when a user right-clicks
+        // on a web page
         browser.register(ShowContextMenuCallback { params, action ->
             menuLocation = with(params.location()) { DpOffset(x().dp, y().dp) }
             menuShowed = true
@@ -101,7 +105,7 @@ fun main() = singleWindowApplication {
 
         browser.navigation().loadUrl("teamdev.com/jxbrowser")
 
-        // The callback can be removed  when it is no longer needed.
+        // Remove the callback when it is no longer needed.
         onDispose {
             browser.removeCallback<ShowContextMenuCallback>()
             engine.close()

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
@@ -40,7 +40,7 @@ import com.teamdev.jxbrowser.dsl.removeCallback
 import com.teamdev.jxbrowser.engine.RenderingMode
 
 /**
- * This example demonstrates how to build a custom context menu using
+ * This example demonstrates how to create a custom context menu using
  * [ShowContextMenuCallback] and Compose API.
  *
  * [Browser] invokes this callback when a user right-clicks on a web page.
@@ -105,9 +105,11 @@ fun main() = singleWindowApplication {
 
         browser.navigation().loadUrl("teamdev.com/jxbrowser")
 
-        // Remove the callback when it is no longer needed.
         onDispose {
+
+            // Remove the callback when it is no longer needed.
             browser.removeCallback<ShowContextMenuCallback>()
+
             engine.close()
         }
     }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/DefaultOpenPopupCallback.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/DefaultOpenPopupCallback.kt
@@ -46,7 +46,7 @@ import kotlinx.coroutines.CoroutineScope
  * This example snippet is meant to be used as a prototype for clients
  * custom implementations.
  */
-fun main() = singleWindowApplication {
+fun main() = singleWindowApplication(title = "Default Open Pop-Up Callback") {
     val engine = remember { Engine(RenderingMode.OFF_SCREEN) }
     val browser = remember { engine.newBrowser() }
 

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/DefaultOpenPopupCallback.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/DefaultOpenPopupCallback.kt
@@ -39,13 +39,6 @@ import kotlinx.coroutines.CoroutineScope
  *
  * It creates and shows a new window with the embedded pop-up browser
  * each time [OpenPopupCallback] is invoked.
- *
- * This implementation matches the one provided in JxBrowser by default.
- * Custom implementation of [OpenPopupCallback] takes precedence
- * over the default one.
- *
- * This example snippet is meant to be used as a prototype for clients
- * custom implementations.
  */
 fun main() = singleWindowApplication(title = "Default Open Pop-Up Callback") {
     val engine = remember { Engine(RenderingMode.OFF_SCREEN) }
@@ -64,8 +57,8 @@ fun main() = singleWindowApplication(title = "Default Open Pop-Up Callback") {
     // Add pop-up windows, if any.
     for (popup in popups) {
         // We associate each `PopupWindow` with a unique key. This helps Compose
-        // efficiently manage the lifecycle of popup components when the list
-        // of popups changes.
+        // efficiently manage the lifecycle of pop-up components when the list
+        // of pop-ups changes.
         key(popup) {
             PopupWindow(popup)
         }
@@ -80,7 +73,7 @@ fun main() = singleWindowApplication(title = "Default Open Pop-Up Callback") {
 
         // `OpenPopupCallback` is responsible for the pop-up window creation.
         browser.register(OpenPopupCallback { params ->
-            popups.addNewPopup(params, scope) // Adds a new popup to the observable list.
+            popups.addNewPopup(params, scope) // Adds a new pop-up to the list.
             OpenPopupCallback.Response.proceed()
         })
 

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/DefaultOpenPopupCallback.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/DefaultOpenPopupCallback.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.window.singleWindowApplication
 import com.teamdev.jxbrowser.browser.callback.CreatePopupCallback
+import com.teamdev.jxbrowser.browser.callback.CreatePopupCallback.Response
 import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback
 import com.teamdev.jxbrowser.compose.BrowserView
 import com.teamdev.jxbrowser.dsl.Engine
@@ -75,7 +76,7 @@ fun main() = singleWindowApplication(title = "Default Open Pop-Up Callback") {
         // This callback decides whether a pop-up should be created.
         // `OpenPopupCallback` callback will NOT be called if this one returns
         // `suppress` instead of `create`.
-        browser.register(CreatePopupCallback { CreatePopupCallback.Response.create() })
+        browser.register(CreatePopupCallback { Response.create() })
 
         // `OpenPopupCallback` is responsible for the pop-up window creation.
         browser.register(OpenPopupCallback { params ->

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/DefaultOpenPopupCallback.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/DefaultOpenPopupCallback.kt
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2024, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.teamdev.jxbrowser.examples.compose.popup
+
+import androidx.compose.runtime.*
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.window.singleWindowApplication
+import com.teamdev.jxbrowser.browser.callback.CreatePopupCallback
+import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback
+import com.teamdev.jxbrowser.compose.BrowserView
+import com.teamdev.jxbrowser.dsl.Engine
+import com.teamdev.jxbrowser.dsl.register
+import com.teamdev.jxbrowser.dsl.removeCallback
+import com.teamdev.jxbrowser.engine.RenderingMode
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * This example demonstrates the default [OpenPopupCallback] implementation
+ * for Compose UI toolkit.
+ *
+ * It creates and shows a new window with the embedded pop-up browser.
+ */
+fun main() = singleWindowApplication {
+    val engine = remember { Engine(RenderingMode.OFF_SCREEN) }
+    val browser = remember { engine.newBrowser() }
+
+    // Store pop-up windows.
+    val popups = remember { mutableStateListOf<PopupWindowState>() }
+
+    // Remember the coroutine scope to update the pop-up window after creation.
+    // For example, to pick up page's title then it completes loading.
+    val scope = rememberCoroutineScope()
+
+    // Add browser view.
+    BrowserView(browser)
+
+    // Add pop-up windows, if any.
+    for (popup in popups) {
+        // We associate each `PopupWindow` with a unique key. This helps Compose
+        // efficiently manage the lifecycle of popup components when the list
+        // of popups changes.
+        key(popup) {
+            PopupWindow(popup)
+        }
+    }
+
+    DisposableEffect(Unit) {
+
+        // This callback decides whether a pop-up should be created.
+        // `OpenPopupCallback` callback will NOT be called if this one returns
+        // `suppress` instead of `create`.
+        browser.register(CreatePopupCallback { CreatePopupCallback.Response.create() })
+
+        // This one is responsible for the pop-up window creation.
+        browser.register(OpenPopupCallback { params ->
+            popups.add(params, scope) // Adds a new popup to the observable list.
+            OpenPopupCallback.Response.proceed()
+        })
+
+        browser.navigation().loadUrl("teamdev.com/jxbrowser")
+
+        onDispose {
+
+            // Remove the callbacks when they are no longer needed.
+            browser.removeCallback<CreatePopupCallback>()
+            browser.removeCallback<OpenPopupCallback>()
+
+            engine.close()
+        }
+    }
+}
+
+/**
+ * Creates and adds a new instance of [PopupWindowState] to this list.
+ *
+ * The created pop-up is removed from the list automatically
+ * when it is closed.
+ */
+fun SnapshotStateList<PopupWindowState>.add(
+    params: OpenPopupCallback.Params,
+    scope: CoroutineScope,
+) = add(PopupWindowState(params, scope, onClose = { remove(it) }))

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/PopupWindow.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/PopupWindow.kt
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2024, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.teamdev.jxbrowser.examples.compose.popup
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.window.Window
+import com.teamdev.jxbrowser.compose.BrowserView
+
+/**
+ * Creates a pop-up window.
+ */
+@Composable
+fun PopupWindow(state: PopupWindowState) {
+    Window(
+        create = { state.window },
+        dispose = ComposeWindow::dispose
+    ) {
+        BrowserView(state.browser)
+        DisposableEffect(Unit) {
+            state.adjustWindowSize()
+            onDispose {
+                state.close()
+            }
+        }
+    }
+}

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/PopupWindowState.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/PopupWindowState.kt
@@ -1,0 +1,169 @@
+/*
+ *  Copyright 2024, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.teamdev.jxbrowser.examples.compose.popup
+
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowState
+import com.teamdev.jxbrowser.browser.Browser
+import com.teamdev.jxbrowser.browser.callback.OpenPopupCallback
+import com.teamdev.jxbrowser.browser.event.BrowserClosed
+import com.teamdev.jxbrowser.browser.event.TitleChanged
+import com.teamdev.jxbrowser.browser.event.UpdateBoundsRequested
+import com.teamdev.jxbrowser.dsl.subscribe
+import com.teamdev.jxbrowser.ui.Point
+import com.teamdev.jxbrowser.ui.Rect
+import com.teamdev.jxbrowser.ui.internal.ApproximateBounds
+import com.teamdev.jxbrowser.ui.internal.ApproximateBounds.fuzzyEqual
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.awt.Dimension
+import java.awt.Insets
+import java.awt.Window
+import javax.swing.JFrame.DISPOSE_ON_CLOSE
+
+/**
+ * State of [PopupWindow].
+ *
+ * @param [params] the parameters of [OpenPopupCallback].
+ * @param [scope] the coroutine scope used to update Compose observables.
+ * @param [onClose] the callback to be called when the popup is closed.
+ */
+class PopupWindowState(
+    params: OpenPopupCallback.Params,
+    scope: CoroutineScope,
+    private val onClose: (PopupWindowState) -> Unit
+) : AutoCloseable {
+
+    private companion object {
+        val DEFAULT_POPUP_SIZE = Dimension(800, 600)
+    }
+
+    /**
+     * The pop-up browser.
+     */
+    val browser: Browser = params.popupBrowser()
+
+    /**
+     * A [ComposeWindow] to show the pop-up window.
+     *
+     * We intentionally avoid using the standard [Window] composable for
+     * creating the windows because, at the moment, Compose has a couple of
+     * bugs related to dynamic window resizing when using [WindowState].
+     */
+    val window: ComposeWindow = ComposeWindow().apply {
+        with(params.initialBounds()) {
+            defaultCloseOperation = DISPOSE_ON_CLOSE
+            size = if (size().isEmpty) DEFAULT_POPUP_SIZE else Dimension(width(), height())
+            location = java.awt.Point(0, 0)
+        }
+    }
+
+    init {
+        browser.subscribe<TitleChanged> {
+            scope.launch { window.title = it.title() }
+        }
+        browser.subscribe<UpdateBoundsRequested> {
+            scope.launch { window.bounds(it.bounds()) }
+        }
+        browser.subscribe<BrowserClosed> {
+            scope.launch {
+                window.isVisible = false
+                window.dispose()
+            }
+        }
+    }
+
+    /**
+     * Adjusts the window size to account for insets.
+     *
+     * When a window is composed into a Compose layout, its dimensions already
+     * include window insets. Therefore, to achieve the desired size for the
+     * window content, we must add the values of these insets.
+     *
+     * Note that this method is only called when the window enters the
+     * composition. At this point, the window becomes visible, and its
+     * insets become available.
+     */
+    fun adjustWindowSize() {
+        val currentSize = window.size
+        val insets = window.insets
+        window.size = currentSize.withInsets(insets)
+    }
+
+    /**
+     * Sets the position and size for this [ComposeWindow] based on the
+     * provided [bounds].
+     *
+     * This method updates the window bounds expecting the window content bounds
+     * received from [UpdateBoundsRequested] event. If the screen position
+     * of the window content hasn't changed, it doesn't update the window
+     * position to avoid unintentional shifting.
+     */
+    private fun ComposeWindow.bounds(bounds: Rect) = with(bounds) {
+        size = Dimension(width(), height()).withInsets(insets)
+        if (origin().isDifferent()) {
+            location = java.awt.Point(x(), y())
+        }
+    }
+
+    /**
+     * Checks if this [Point] is different from the current screen position of
+     * the window content.
+     *
+     * It uses a fuzzy comparison, since there may be inaccuracies when
+     * converting numbers after scaling.
+     *
+     * @see ApproximateBounds
+     */
+    private fun Point.isDifferent(): Boolean {
+        val (x, y) = window.position
+        return !fuzzyEqual(Point.of(x, y), this)
+    }
+
+    override fun close() {
+        onClose(this)
+        browser.close()
+    }
+}
+
+/**
+ * Creates a new [Dimension] instance by adding the values of this
+ * [Dimension] with the given [insets].
+ */
+private fun Dimension.withInsets(insets: Insets) = Dimension(
+    width + insets.left + insets.right,
+    height + insets.top + insets.bottom
+)
+
+/**
+ * Returns the absolute position of this [Window].
+ */
+internal val Window.position: IntOffset
+    get() = if (isVisible) {
+        IntOffset(
+            x = locationOnScreen.x + insets.left,
+            y = locationOnScreen.y + insets.top
+        )
+    } else {
+        IntOffset.Zero
+    }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/PopupWindowState.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/popup/PopupWindowState.kt
@@ -46,7 +46,7 @@ import javax.swing.JFrame.DISPOSE_ON_CLOSE
  *
  * @param [params] the parameters of [OpenPopupCallback].
  * @param [scope] the coroutine scope used to update Compose observables.
- * @param [onClose] the callback to be called when the popup is closed.
+ * @param [onClose] the callback to be called when the pop-up is closed.
  */
 class PopupWindowState(
     params: OpenPopupCallback.Params,
@@ -71,11 +71,9 @@ class PopupWindowState(
      * bugs related to dynamic window resizing when using [WindowState].
      */
     val window: ComposeWindow = ComposeWindow().apply {
-        with(params.initialBounds()) {
-            defaultCloseOperation = DISPOSE_ON_CLOSE
-            size = if (size().isEmpty) DEFAULT_POPUP_SIZE else Dimension(width(), height())
-            location = java.awt.Point(0, 0)
-        }
+        defaultCloseOperation = DISPOSE_ON_CLOSE
+        size = popupSize(params)
+        location = java.awt.Point(0, 0)
     }
 
     init {
@@ -139,6 +137,20 @@ class PopupWindowState(
         val (x, y) = window.position
         return !fuzzyEqual(Point.of(x, y), this)
     }
+
+    /**
+     * Returns pop-up size if the one is specified in the given [params].
+     *
+     * Otherwise, returns the [DEFAULT_POPUP_SIZE].
+     */
+    private fun popupSize(params: OpenPopupCallback.Params): Dimension =
+        with(params.initialBounds()) {
+            if (size().isEmpty) {
+                DEFAULT_POPUP_SIZE
+            } else {
+                Dimension(width(), height())
+            }
+        }
 
     override fun close() {
         onClose(this)


### PR DESCRIPTION
This PR adds the basic examples of using JxBrowser with Compose Desktop.

The following snippets have been created:

1. `ComposeBrowserView`.
2. `BitmapToComposeImage`.
3. `CustomContextMenu`.
4. `DefaultOpenPopupCallback`.

Please note, JavaFX is a dependency now due to migration to Java 17.