### PR TITLE
Update JxBrowser to 7.40.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     id("com.teamdev.jxbrowser") version "1.1.0"
 }
 
-val jxBrowserVersion by extra { "7.39.2" } // The version of JxBrowser used in the examples.
+val jxBrowserVersion by extra { "7.40.0" } // The version of JxBrowser used in the examples.
 val guavaVersion by extra { "29.0-jre" } // Some of the examples use Guava.
 
 allprojects {


### PR DESCRIPTION
In this changeset, we update the JxBrowser version to 7.40.0 in `build.gradle.kts`

Issue: https://github.com/TeamDev-IP/JxBrowser-Docs/issues/1591