### PR TITLE
Use example-specific web-pages for Java examples

### DIFF
--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DefaultZoomLevel.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DefaultZoomLevel.java
@@ -62,6 +62,6 @@ public final class DefaultZoomLevel {
         engine.zoomLevels().defaultLevel(ZoomLevel.P_300);
 
         browser.mainFrame()
-                .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com"));
+               .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com"));
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DefaultZoomLevel.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DefaultZoomLevel.java
@@ -61,6 +61,7 @@ public final class DefaultZoomLevel {
 
         engine.zoomLevels().defaultLevel(ZoomLevel.P_300);
 
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.mainFrame()
+                .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com"));
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DefaultZoomLevel.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DefaultZoomLevel.java
@@ -61,7 +61,6 @@ public final class DefaultZoomLevel {
 
         engine.zoomLevels().defaultLevel(ZoomLevel.P_300);
 
-        browser.mainFrame()
-               .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com"));
+        browser.navigation().loadUrl("https://html5test.teamdev.com");
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DisableZoom.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DisableZoom.java
@@ -59,7 +59,8 @@ public final class DisableZoom {
             frame.setVisible(true);
         });
 
-        browser.navigation().loadUrlAndWait("https://www.google.com");
+        browser.mainFrame()
+                .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com"));
 
         // Disabling zoom.
         browser.zoom().disable();

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DisableZoom.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DisableZoom.java
@@ -60,7 +60,7 @@ public final class DisableZoom {
         });
 
         browser.mainFrame()
-                .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com"));
+               .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com"));
 
         // Disabling zoom.
         browser.zoom().disable();

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/DisableZoom.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/DisableZoom.java
@@ -59,8 +59,7 @@ public final class DisableZoom {
             frame.setVisible(true);
         });
 
-        browser.mainFrame()
-               .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com"));
+        browser.navigation().loadUrl("https://html5test.teamdev.com");
 
         // Disabling zoom.
         browser.zoom().disable();

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/FilterCookies.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/FilterCookies.java
@@ -72,6 +72,6 @@ public final class FilterCookies {
             return CanGetCookiesCallback.Response.cannot();
         });
 
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.navigation().loadUrl("https://html5test.teamdev.com");
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/FilterImages.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/FilterImages.java
@@ -35,11 +35,10 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to handle all resources such as HTML, PNG,
- * JavaScript, CSS files, and decide whether web browser engine should load
- * them from web server.
+ * This example demonstrates how to handle all resources such as HTML, PNG, JavaScript, CSS files
+ * and decide whether web browser engine should load them from web server or not.
  *
- * <p>In this example we cancel loading of all images.
+ * <p>For example, in this example we cancel loading of all images.
  */
 public final class FilterImages {
 
@@ -71,6 +70,6 @@ public final class FilterImages {
             return BeforeUrlRequestCallback.Response.proceed();
         });
 
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.navigation().loadUrl("https://webglsamples.org/");
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/FindText.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/FindText.java
@@ -65,6 +65,6 @@ public final class FindText {
             frame.setVisible(true);
         });
 
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.navigation().loadUrl("https://html5test.teamdev.com/");
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/InterceptRequest.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/InterceptRequest.java
@@ -68,7 +68,7 @@ public final class InterceptRequest {
             frame.setVisible(true);
         });
 
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.navigation().loadUrl("https://html5test.teamdev.com/");
     }
 
     private static final class InterceptHttpsCallback implements InterceptUrlRequestCallback {

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/LoadUrl.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/LoadUrl.java
@@ -59,7 +59,6 @@ public final class LoadUrl {
             frame.setVisible(true);
         });
 
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.navigation().loadUrl("https://html5test.teamdev.com/");
     }
 }
-

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/LocalWebStorage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/LocalWebStorage.java
@@ -39,7 +39,7 @@ public final class LocalWebStorage {
     public static void main(String[] args) {
         try (Engine engine = Engine.newInstance(OFF_SCREEN)) {
             Browser browser = engine.newBrowser();
-            browser.navigation().loadUrlAndWait("https://www.google.com");
+            browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
             browser.mainFrame().ifPresent(frame -> {
                 frame.localStorage().putItem(KEY, "Tom");
                 System.out.println((String) frame.executeJavaScript(

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJava.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJava.java
@@ -64,8 +64,7 @@ public final class PrintFromJava {
             frame.setLocationRelativeTo(null);
             frame.setVisible(true);
 
-            browser.navigation()
-                   .loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+            browser.navigation().loadUrl("https://en.wikipedia.org/wiki/Printing");
         });
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJava.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJava.java
@@ -35,9 +35,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to show the print preview dialog where
- * an end-user can select the required printing options and print the currently
- * loaded web page.
+ * This example demonstrates how to show the Print Preview dialog where you can select the required
+ * printing options and print the currently loaded web page.
  */
 public final class PrintFromJava {
 
@@ -65,7 +64,8 @@ public final class PrintFromJava {
             frame.setLocationRelativeTo(null);
             frame.setVisible(true);
 
-            browser.navigation().loadUrl("https://www.google.com");
+            browser.navigation()
+                    .loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
         });
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJava.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintFromJava.java
@@ -65,7 +65,7 @@ public final class PrintFromJava {
             frame.setVisible(true);
 
             browser.navigation()
-                    .loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+                   .loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
         });
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -77,8 +77,7 @@ public final class PrintSettings {
             // #enddocfragment "Proceed"
         });
         // #enddocfragment "Callback"
-        browser.navigation()
-               .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+        browser.navigation().loadUrlAndWait("https://en.wikipedia.org/wiki/Printing");
         browser.mainFrame().ifPresent(Frame::print);
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -78,7 +78,7 @@ public final class PrintSettings {
         });
         // #enddocfragment "Callback"
         browser.navigation()
-                .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+               .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
         browser.mainFrame().ifPresent(Frame::print);
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintSettings.java
@@ -36,8 +36,8 @@ import com.teamdev.jxbrowser.print.SystemPrinter.HtmlSettings;
 import com.teamdev.jxbrowser.print.event.PrintCompleted;
 
 /**
- * This example demonstrates how to print the currently loaded web page
- * via the default system printer.
+ * This example demonstrates how to configure print settings programmatically and print the
+ * currently loaded web page on the default system printer.
  */
 public final class PrintSettings {
 
@@ -77,7 +77,8 @@ public final class PrintSettings {
             // #enddocfragment "Proceed"
         });
         // #enddocfragment "Callback"
-        browser.navigation().loadUrlAndWait("https://google.com");
+        browser.navigation()
+                .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
         browser.mainFrame().ifPresent(Frame::print);
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
@@ -65,7 +65,7 @@ public final class PrintToPdf {
             tell.proceed(pdfPrinter);
         });
         browser.navigation()
-                .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+               .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
         browser.mainFrame().ifPresent(Frame::print);
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
@@ -50,7 +50,7 @@ public final class PrintToPdf {
                     params.printers().pdfPrinter();
             PrintJob<HtmlSettings> printJob = pdfPrinter.printJob();
             printJob.settings()
-                    .pdfFilePath(Paths.get("dynamic-cubemap.pdf").toAbsolutePath())
+                    .pdfFilePath(Paths.get("wikipedia-printing.pdf").toAbsolutePath())
                     .enablePrintingBackgrounds()
                     .orientation(PORTRAIT)
                     .apply();

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
@@ -35,8 +35,9 @@ import com.teamdev.jxbrowser.print.event.PrintCompleted;
 import java.nio.file.Paths;
 
 /**
- * This example demonstrates how to save the currently loaded web page
- * as a PDF document.
+ * This example demonstrates how to configure print settings programmatically and print the
+ * currently loaded web page using the built-in PDF printer. In general, it shows how to save the
+ * currently loaded web page as a PDF document.
  */
 public final class PrintToPdf {
 
@@ -49,7 +50,7 @@ public final class PrintToPdf {
                     params.printers().pdfPrinter();
             PrintJob<HtmlSettings> printJob = pdfPrinter.printJob();
             printJob.settings()
-                    .pdfFilePath(Paths.get("google.pdf").toAbsolutePath())
+                    .pdfFilePath(Paths.get("dynamic-cubemap.pdf").toAbsolutePath())
                     .enablePrintingBackgrounds()
                     .orientation(PORTRAIT)
                     .apply();
@@ -63,7 +64,8 @@ public final class PrintToPdf {
             });
             tell.proceed(pdfPrinter);
         });
-        browser.navigation().loadUrlAndWait("https://google.com");
+        browser.navigation()
+                .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
         browser.mainFrame().ifPresent(Frame::print);
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/PrintToPdf.java
@@ -64,8 +64,7 @@ public final class PrintToPdf {
             });
             tell.proceed(pdfPrinter);
         });
-        browser.navigation()
-               .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+        browser.navigation().loadUrlAndWait("https://en.wikipedia.org/wiki/Printing");
         browser.mainFrame().ifPresent(Frame::print);
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SaveWebPage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SaveWebPage.java
@@ -62,7 +62,7 @@ public final class SaveWebPage {
         });
 
         browser.navigation()
-                .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+               .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
 
         Path file = Paths.get("index.html");
         Path dir = Paths.get("resources_dir");

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SaveWebPage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SaveWebPage.java
@@ -61,8 +61,7 @@ public final class SaveWebPage {
             frame.setVisible(true);
         });
 
-        browser.navigation()
-               .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+        browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
 
         Path file = Paths.get("index.html");
         Path dir = Paths.get("resources_dir");

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SaveWebPage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SaveWebPage.java
@@ -61,7 +61,8 @@ public final class SaveWebPage {
             frame.setVisible(true);
         });
 
-        browser.navigation().loadUrlAndWait("https://www.google.com");
+        browser.navigation()
+                .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
 
         Path file = Paths.get("index.html");
         Path dir = Paths.get("resources_dir");

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SslCertificateVerifier.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SslCertificateVerifier.java
@@ -65,14 +65,14 @@ public final class SslCertificateVerifier {
         engine.network().set(VerifyCertificateCallback.class, params -> {
             String host = params.host().value();
             System.out.println("Verifying certificate for " + host + "...");
-            // Reject SSL certificate for all "google.com" hosts.
-            if (host.contains("google.com")) {
+            // Reject SSL certificate for all "teamdev.com" hosts.
+            if (host.contains("teamdev.com")) {
                 return Response.invalid(AUTHORITY_INVALID);
             } else {
                 return Response.valid();
             }
         });
 
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.navigation().loadUrl("https://html5test.teamdev.com/");
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/ZoomLevel.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/ZoomLevel.java
@@ -80,6 +80,6 @@ public final class ZoomLevel {
             }
         });
 
-        navigation.loadUrl("https://www.google.com");
+        navigation.loadUrl("https://html5test.teamdev.com/");
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BitmapToJavaFxImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BitmapToJavaFxImage.java
@@ -47,7 +47,8 @@ public final class BitmapToJavaFxImage {
             browser.resize(1024, 768);
 
             // Load the required web page and wait until it is loaded completely
-            browser.navigation().loadUrlAndWait("https://www.google.com");
+            browser.navigation()
+                    .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
 
             Bitmap bitmap = browser.bitmap();
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BitmapToJavaFxImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BitmapToJavaFxImage.java
@@ -47,8 +47,7 @@ public final class BitmapToJavaFxImage {
             browser.resize(1024, 768);
 
             // Load the required web page and wait until it is loaded completely
-            browser.navigation()
-                   .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+            browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
 
             Bitmap bitmap = browser.bitmap();
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BitmapToJavaFxImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BitmapToJavaFxImage.java
@@ -48,7 +48,7 @@ public final class BitmapToJavaFxImage {
 
             // Load the required web page and wait until it is loaded completely
             browser.navigation()
-                    .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+                   .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
 
             Bitmap bitmap = browser.bitmap();
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInJFxPanel.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInJFxPanel.java
@@ -20,17 +20,14 @@
 
 package com.teamdev.jxbrowser.examples.javafx;
 
-import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
 
 import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
-import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.view.javafx.BrowserView;
 import java.awt.BorderLayout;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.util.concurrent.CountDownLatch;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.Scene;

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInJFxPanel.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInJFxPanel.java
@@ -20,14 +20,17 @@
 
 package com.teamdev.jxbrowser.examples.javafx;
 
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
 
 import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
+import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.view.javafx.BrowserView;
 import java.awt.BorderLayout;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.util.concurrent.CountDownLatch;
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.scene.Scene;
@@ -65,6 +68,6 @@ public final class BrowserViewInJFxPanel {
             frame.setLocationRelativeTo(null);
             frame.setVisible(true);
         });
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.navigation().loadUrl("https://html5test.teamdev.com/");
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInTabPane.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInTabPane.java
@@ -48,7 +48,7 @@ public final class BrowserViewInTabPane extends Application {
 
         Browser browserOne = engine.newBrowser();
         browserOne.navigation()
-                .loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+                  .loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
         BrowserView viewOne = BrowserView.newInstance(browserOne);
 
         Tab tabOne = new Tab("Browser One");

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInTabPane.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/BrowserViewInTabPane.java
@@ -47,14 +47,15 @@ public final class BrowserViewInTabPane extends Application {
         Engine engine = Engine.newInstance(OFF_SCREEN);
 
         Browser browserOne = engine.newBrowser();
-        browserOne.navigation().loadUrl("https://www.google.com");
+        browserOne.navigation()
+                .loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
         BrowserView viewOne = BrowserView.newInstance(browserOne);
 
         Tab tabOne = new Tab("Browser One");
         tabOne.setContent(viewOne);
 
         Browser browserTwo = engine.newBrowser();
-        browserTwo.navigation().loadUrl("https://www.teamdev.com");
+        browserTwo.navigation().loadUrl("https://html5test.teamdev.com/");
         BrowserView viewTwo = BrowserView.newInstance(browserTwo);
 
         Tab tabTwo = new Tab("Browser Two");

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/JavaFxBrowserView.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/javafx/JavaFxBrowserView.java
@@ -51,7 +51,7 @@ public final class JavaFxBrowserView extends Application {
         primaryStage.setScene(scene);
         primaryStage.show();
 
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.navigation().loadUrl("https://html5test.teamdev.com/");
         primaryStage.setOnCloseRequest(event -> engine.close());
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BitmapToSwingImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BitmapToSwingImage.java
@@ -45,8 +45,7 @@ public final class BitmapToSwingImage {
             browser.resize(1024, 768);
 
             // Load the required web page and wait until it is loaded completely
-            browser.navigation()
-                   .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+            browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
 
             Bitmap bitmap = browser.bitmap();
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BitmapToSwingImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BitmapToSwingImage.java
@@ -45,7 +45,8 @@ public final class BitmapToSwingImage {
             browser.resize(1024, 768);
 
             // Load the required web page and wait until it is loaded completely
-            browser.navigation().loadUrlAndWait("https://www.google.com");
+            browser.navigation()
+                    .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
 
             Bitmap bitmap = browser.bitmap();
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BitmapToSwingImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BitmapToSwingImage.java
@@ -46,7 +46,7 @@ public final class BitmapToSwingImage {
 
             // Load the required web page and wait until it is loaded completely
             browser.navigation()
-                    .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+                   .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
 
             Bitmap bitmap = browser.bitmap();
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJInternalFrame.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJInternalFrame.java
@@ -42,8 +42,10 @@ public final class BrowserViewInJInternalFrame {
     public static void main(String[] args) {
         SwingUtilities.invokeLater(() -> {
             JDesktopPane pane = new JDesktopPane();
-            pane.add(createInternalFrame("TeamDev", "https://www.teamdev.com", 0));
-            pane.add(createInternalFrame("Google", "https://www.google.com", 100));
+            pane.add(createInternalFrame("HTML 5 Test",
+                    "https://html5test.teamdev.com/", 0));
+            pane.add(createInternalFrame("WebGL Dynamic Cubemap",
+                    "https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html", 100));
 
             JFrame frame = new JFrame("BrowserView In JInternalFrame");
             frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJTabbedPane.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJTabbedPane.java
@@ -62,7 +62,10 @@ public final class BrowserViewInJTabbedPane {
             frame.setVisible(true);
         });
 
-        browserOne.navigation().loadUrl("https://www.google.com");
-        browserTwo.navigation().loadUrl("https://www.teamdev.com");
+        browserOne.mainFrame()
+                .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com/"));
+        browserTwo.mainFrame()
+                .ifPresent(mainFrame -> mainFrame.loadHtml(
+                        "https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html"));
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJTabbedPane.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJTabbedPane.java
@@ -63,9 +63,9 @@ public final class BrowserViewInJTabbedPane {
         });
 
         browserOne.mainFrame()
-                .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com/"));
+                  .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com/"));
         browserTwo.mainFrame()
-                .ifPresent(mainFrame -> mainFrame.loadHtml(
-                        "https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html"));
+                  .ifPresent(mainFrame -> mainFrame.loadHtml(
+                          "https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html"));
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJTabbedPane.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/BrowserViewInJTabbedPane.java
@@ -62,10 +62,8 @@ public final class BrowserViewInJTabbedPane {
             frame.setVisible(true);
         });
 
-        browserOne.mainFrame()
-                  .ifPresent(mainFrame -> mainFrame.loadHtml("https://html5test.teamdev.com/"));
-        browserTwo.mainFrame()
-                  .ifPresent(mainFrame -> mainFrame.loadHtml(
-                          "https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html"));
+        browserOne.navigation().loadUrl("https://html5test.teamdev.com");
+        browserTwo.navigation()
+                  .loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/CustomContextMenu.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/CustomContextMenu.java
@@ -71,7 +71,7 @@ public final class CustomContextMenu {
             frame.setVisible(true);
         });
 
-        browser.navigation().loadUrl("https://google.com/");
+        browser.navigation().loadUrl("https://html5test.teamdev.com/");
     }
 
     private static class ShowCustomContextMenu implements ShowContextMenuCallback {

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/SwingBrowserView.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swing/SwingBrowserView.java
@@ -58,6 +58,6 @@ public final class SwingBrowserView {
             frame.setVisible(true);
         });
 
-        browser.navigation().loadUrl("https://google.com/");
+        browser.navigation().loadUrl("https://html5test.teamdev.com/");
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/BitmapToSwtImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/BitmapToSwtImage.java
@@ -20,15 +20,12 @@
 
 package com.teamdev.jxbrowser.examples.swt;
 
-import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
 
 import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
-import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.ui.Bitmap;
 import com.teamdev.jxbrowser.view.swt.graphics.BitmapImage;
-import java.util.concurrent.CountDownLatch;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/BitmapToSwtImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/BitmapToSwtImage.java
@@ -47,8 +47,7 @@ public final class BitmapToSwtImage {
             browser.resize(1024, 768);
 
             // Load the required web page and wait until it is loaded completely
-            browser.navigation()
-                   .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+            browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
 
             Bitmap bitmap = browser.bitmap();
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/BitmapToSwtImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/BitmapToSwtImage.java
@@ -20,12 +20,15 @@
 
 package com.teamdev.jxbrowser.examples.swt;
 
+import static com.google.common.util.concurrent.Uninterruptibles.awaitUninterruptibly;
 import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
 
 import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
+import com.teamdev.jxbrowser.navigation.event.FrameLoadFinished;
 import com.teamdev.jxbrowser.ui.Bitmap;
 import com.teamdev.jxbrowser.view.swt.graphics.BitmapImage;
+import java.util.concurrent.CountDownLatch;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
@@ -47,7 +50,8 @@ public final class BitmapToSwtImage {
             browser.resize(1024, 768);
 
             // Load the required web page and wait until it is loaded completely
-            browser.navigation().loadUrlAndWait("https://www.google.com");
+            browser.navigation()
+                    .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
 
             Bitmap bitmap = browser.bitmap();
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/BitmapToSwtImage.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/BitmapToSwtImage.java
@@ -51,7 +51,7 @@ public final class BitmapToSwtImage {
 
             // Load the required web page and wait until it is loaded completely
             browser.navigation()
-                    .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
+                   .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html");
 
             Bitmap bitmap = browser.bitmap();
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/SwtBrowserView.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/swt/SwtBrowserView.java
@@ -49,7 +49,7 @@ public final class SwtBrowserView {
         shell.pack();
         shell.open();
 
-        browser.navigation().loadUrl("https://www.google.com");
+        browser.navigation().loadUrl("https://html5test.teamdev.com/");
 
         while (!shell.isDisposed()) {
             if (!display.readAndDispatch()) {

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/DefaultZoomLevel.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/DefaultZoomLevel.kt
@@ -42,7 +42,7 @@ fun main() {
         BrowserView(browser)
         LaunchedEffect(Unit) {
             engine.zoomLevels.defaultLevel = ZoomLevel.P_300
-            browser.navigation.loadUrl("https://www.google.com")
+            browser.navigation.loadUrl("https://html5test.teamdev.com/")
         }
     }
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/DisableZoom.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/DisableZoom.kt
@@ -41,7 +41,7 @@ fun main() {
     singleWindowApplication(title = "Disable zoom") {
         BrowserView(browser)
         LaunchedEffect(Unit) {
-            browser.navigation.loadUrlAndWait("https://www.google.com")
+            browser.navigation.loadUrlAndWait("https://html5test.teamdev.com/")
             browser.zoom.enabled = false // Disables zoom.
             browser.zoom.level = ZoomLevel.P_300 // Set zoom to 300% that will NOT be applied.
         }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/FilterCookies.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/FilterCookies.kt
@@ -48,7 +48,7 @@ fun main() {
     }
 
     val browser = engine.newBrowser()
-    browser.navigation.loadUrlAndWait("https://google.com")
+    browser.navigation.loadUrlAndWait("https://html5test.teamdev.com/")
 
     // The suppressed cookies have been printed to the console.
     engine.close()

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/FilterImages.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/FilterImages.kt
@@ -54,7 +54,7 @@ fun main() {
     singleWindowApplication(title = "Filter images") {
         BrowserView(browser)
         LaunchedEffect(Unit) {
-            browser.navigation.loadUrl("https://www.google.com")
+            browser.navigation.loadUrl("https://webglsamples.org/")
         }
     }
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/FindText.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/FindText.kt
@@ -48,7 +48,7 @@ fun main() = singleWindowApplication(title = "Find text") {
     }
 
     LaunchedEffect(Unit) {
-        browser.navigation.loadUrl("https://www.google.com")
+        browser.navigation.loadUrl("https://html5test.teamdev.com/")
     }
 }
 

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/InterceptRequest.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/InterceptRequest.kt
@@ -49,7 +49,7 @@ fun main() {
     singleWindowApplication(title = "Intercept request") {
         BrowserView(browser)
         LaunchedEffect(Unit) {
-            browser.navigation.loadUrl("https://www.google.com")
+            browser.navigation.loadUrl("https://html5test.teamdev.com/")
         }
     }
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/LoadUrl.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/LoadUrl.kt
@@ -39,7 +39,7 @@ fun main() {
     singleWindowApplication(title = "Load URL") {
         BrowserView(browser)
         LaunchedEffect(Unit) {
-            browser.navigation.loadUrl("https://www.google.com")
+            browser.navigation.loadUrl("https://html5test.teamdev.com/")
         }
     }
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/LocalWebStorage.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/LocalWebStorage.kt
@@ -37,7 +37,7 @@ import com.teamdev.jxbrowser.frame.Frame
  */
 fun main() = Engine(RenderingMode.OFF_SCREEN).use { engine ->
     val browser = engine.newBrowser()
-    browser.navigation.loadUrlAndWait("https://www.google.com")
+    browser.navigation.loadUrlAndWait("https://html5test.teamdev.com/")
 
     val frame = browser.mainFrame!!
     frame.localStorage[KEY] = "Tom"

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintFromKotlin.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintFromKotlin.kt
@@ -49,6 +49,6 @@ fun main() = singleWindowApplication(title = "Print from Java") {
     }
 
     LaunchedEffect(Unit) {
-        browser.navigation.loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
+        browser.navigation.loadUrl("https://en.wikipedia.org/wiki/Printing")
     }
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintFromKotlin.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintFromKotlin.kt
@@ -49,6 +49,6 @@ fun main() = singleWindowApplication(title = "Print from Java") {
     }
 
     LaunchedEffect(Unit) {
-        browser.navigation.loadUrl("https://www.google.com")
+        browser.navigation.loadUrl("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
     }
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintSettings.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintSettings.kt
@@ -79,7 +79,6 @@ fun main() {
         tell.proceed(printer)
     })
 
-    browser.navigation
-           .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
+    browser.navigation.loadUrlAndWait("https://en.wikipedia.org/wiki/Printing")
     browser.mainFrame?.print()
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintSettings.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintSettings.kt
@@ -79,6 +79,7 @@ fun main() {
         tell.proceed(printer)
     })
 
-    browser.navigation.loadUrlAndWait("https://google.com")
+    browser.navigation
+           .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
     browser.mainFrame?.print()
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintToPdf.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintToPdf.kt
@@ -68,6 +68,7 @@ fun main() {
         tell.proceed(printer)
     })
 
-    browser.navigation.loadUrlAndWait("https://google.com")
+    browser.navigation
+           .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
     browser.mainFrame?.print()
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintToPdf.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintToPdf.kt
@@ -68,7 +68,6 @@ fun main() {
         tell.proceed(printer)
     })
 
-    browser.navigation
-           .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
+    browser.navigation.loadUrlAndWait("https://en.wikipedia.org/wiki/Printing")
     browser.mainFrame?.print()
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintToPdf.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/PrintToPdf.kt
@@ -51,7 +51,7 @@ fun main() {
         val job = printer.job
 
         job.settings()
-            .pdfFilePath(Path("google.pdf").absolute())
+            .pdfFilePath(Path("wikipedia-printing.pdf").absolute())
             .enablePrintingBackgrounds()
             .orientation(Orientation.PORTRAIT)
             .apply()

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/SaveWebPage.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/SaveWebPage.kt
@@ -43,7 +43,8 @@ fun main() {
     singleWindowApplication(title = "Save web page") {
         BrowserView(browser)
         LaunchedEffect(Unit) {
-            browser.navigation.loadUrlAndWait("https://www.google.com")
+            browser.navigation
+                   .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
             browser.saveWebPage(html, resources, SavePageType.COMPLETE_HTML)
                 .also { success ->
                     if (success) {

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/SaveWebPage.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/SaveWebPage.kt
@@ -43,8 +43,7 @@ fun main() {
     singleWindowApplication(title = "Save web page") {
         BrowserView(browser)
         LaunchedEffect(Unit) {
-            browser.navigation
-                   .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
+            browser.navigation.loadUrlAndWait("https://html5test.teamdev.com/")
             browser.saveWebPage(html, resources, SavePageType.COMPLETE_HTML)
                 .also { success ->
                     if (success) {

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/SslCertificateVerifier.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/SslCertificateVerifier.kt
@@ -46,7 +46,7 @@ fun main() {
         println("Verifying certificate for `$host`.")
 
         // Reject SSL certificate for all "google.com" hosts.
-        if (host.contains("google.com")) {
+        if (host.contains("teamdev.com")) {
             invalid(CertVerificationStatus.AUTHORITY_INVALID)
         } else {
             valid()
@@ -56,7 +56,7 @@ fun main() {
     singleWindowApplication(title = "SSL certificate verifier") {
         BrowserView(browser)
         LaunchedEffect(Unit) {
-            browser.navigation.loadUrl("https://www.google.com")
+            browser.navigation.loadUrl("https://html5test.teamdev.com/")
         }
     }
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/ZoomLevel.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/ZoomLevel.kt
@@ -61,7 +61,7 @@ fun main() {
     singleWindowApplication(title = "Change zoom level") {
         BrowserView(browser)
         LaunchedEffect(Unit) {
-            browser.navigation.loadUrl("https://www.google.com")
+            browser.navigation.loadUrl("https://html5test.teamdev.com/")
         }
     }
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
@@ -34,8 +34,7 @@ import javax.imageio.ImageIO
 fun main() {
     val engine = Engine(RenderingMode.OFF_SCREEN)
     val browser = engine.newBrowser().apply { resize(1024, 768) }
-    browser.navigation
-           .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
+    browser.navigation.loadUrlAndWait("https://html5test.teamdev.com/")
 
     // Get `Bitmap` with the image of the currently loaded web page.
     val bitmap = browser.bitmap()

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/BitmapToComposeImage.kt
@@ -34,7 +34,8 @@ import javax.imageio.ImageIO
 fun main() {
     val engine = Engine(RenderingMode.OFF_SCREEN)
     val browser = engine.newBrowser().apply { resize(1024, 768) }
-    browser.navigation.loadUrlAndWait("https://google.com/")
+    browser.navigation
+           .loadUrlAndWait("https://webglsamples.org/dynamic-cubemap/dynamic-cubemap.html")
 
     // Get `Bitmap` with the image of the currently loaded web page.
     val bitmap = browser.bitmap()

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/ComposeBrowserView.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/ComposeBrowserView.kt
@@ -37,6 +37,6 @@ fun main(): Unit = singleWindowApplication(title = "Compose `Browser View`") {
     val browser = remember { engine.newBrowser() }
     BrowserView(browser)
     LaunchedEffect(Unit) {
-        browser.navigation.loadUrl("https://google.com/")
+        browser.navigation.loadUrl("https://html5test.teamdev.com/")
     }
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/CustomContextMenu.kt
@@ -98,7 +98,7 @@ fun main() = singleWindowApplication(title = "Custom context menu") {
             tell.close() // We don't need its actions.
         })
 
-        browser.navigation().loadUrl("teamdev.com/jxbrowser")
+        browser.navigation().loadUrl("https://html5test.teamdev.com/")
 
         onDispose {
 

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/DefaultOpenPopupCallback.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/DefaultOpenPopupCallback.kt
@@ -84,7 +84,7 @@ fun main() = singleWindowApplication(title = "Default `OpenPopupCallback`") {
             OpenPopupCallback.Response.proceed()
         })
 
-        browser.navigation().loadUrl("teamdev.com/jxbrowser")
+        browser.navigation().loadUrl("https://html5test.teamdev.com/")
 
         onDispose {
 

--- a/examples/src/main/resources/browser-view.fxml
+++ b/examples/src/main/resources/browser-view.fxml
@@ -29,6 +29,6 @@
     <FxmlBrowserView fx:id="browserView"/>
   </center>
   <top>
-    <TextField onAction="#loadUrl" text="https://www.google.com" fx:id="textField"/>
+    <TextField onAction="#loadUrl" text="https://html5test.teamdev.com/" fx:id="textField"/>
   </top>
 </BorderPane>


### PR DESCRIPTION
In this changeset, we have utilized example-specific web-pages for our examples.

Issue: TeamDev-IP/JxBrowser/issues/4091