### PR TITLE
Update selenium tutorial

### DIFF
--- a/tutorials/selenium/README.md
+++ b/tutorials/selenium/README.md
@@ -35,9 +35,10 @@ the environment variable contains the `%JAVA_HOME%/bin` directory.
    root [build.gradle.kts](../../build.gradle.kts) you need to update the
    `chromiumVersion` property [here](launcher/build.gradle.kts)
    before running the `downloadChromeDriver` task. Otherwise, Selenium WebDriver
-   will not be able to connect to Chromium. You can find a list of
-   Chromium-to-JxBrowser versions
-   [here](https://teamdev.com/jxbrowser/docs/guides/introduction/licensing/#chromium-open-source-components%E2%80%99-licenses)
+   will not be able to connect to Chromium. You can find the Chromium version of
+   the specific JxBrowser version in
+   the [release notes](https://teamdev.com/jxbrowser/release-notes/) of the
+   last, or in one of the previous version where Chromium has been updated.
 2. [Insert your license key](https://teamdev.com/jxbrowser/docs/guides/introduction/licensing/#adding-the-license-to-a-project)
    into [the test application](./target-app/src/main/java/TargetApp.java).
 3. In the [root](../..) directory, run the `buildApplication` task
@@ -48,6 +49,7 @@ the environment variable contains the `%JAVA_HOME%/bin` directory.
    ```bash
    gradlew target-app:clean target-app:buildApplication
    ```
+   
    **macOS/Linux:**
    ```bash
    ./gradlew target-app:clean target-app:buildApplication

--- a/tutorials/selenium/README.md
+++ b/tutorials/selenium/README.md
@@ -11,7 +11,7 @@ The tutorial is available on all supported platforms.
 
 ## Prerequisites
 
-The tutorial requires the `jpackage` tool available in `PATH` so make sure that
+The tutorial requires the `jpackage` tool available in `PATH`, so make sure that
 the environment variable contains the `%JAVA_HOME%/bin` directory.
 
 ## Building and Launching

--- a/tutorials/selenium/README.md
+++ b/tutorials/selenium/README.md
@@ -57,7 +57,7 @@ the environment variable contains the `%JAVA_HOME%/bin` directory.
    
 4. Run [Selenium](launcher/src/main/java/SeleniumLauncher.java).
 5. If everything configured properly, you will see the launched test
-   application, and the following in the console output:
+   application, and the following console output:
    ```
    Current URL: about:blank
    // or

--- a/tutorials/selenium/README.md
+++ b/tutorials/selenium/README.md
@@ -7,8 +7,6 @@ JxBrowser.
 Creating of these example projects is described in
 the [tutorial](https://jxbrowser-support.teamdev.com/docs/tutorials/integration/selenium.html).
 
-The tutorial is available on all supported platforms.
-
 ## Prerequisites
 
 The tutorial requires the `jpackage` tool available in `PATH`, so make sure that
@@ -30,17 +28,16 @@ the environment variable contains the `%JAVA_HOME%/bin` directory.
    ./gradlew launcher:downloadChromeDriver
    ```
 
-   > **_NOTE:_** Each version of ChromeDriver corresponds to the same version of
-   Chromium used in JxBrowser. So if you change the JxBrowser version in the
-   root [build.gradle.kts](../../build.gradle.kts) you need to update the
+   Each version of ChromeDriver corresponds to the Chromium version used in
+   JxBrowser. If you change the JxBrowser version
+   in [build.gradle.kts](../../build.gradle.kts) you need to update the
    `chromiumVersion` property [here](launcher/build.gradle.kts)
    before running the `downloadChromeDriver` task. Otherwise, Selenium WebDriver
-   will not be able to connect to Chromium. You can find the Chromium version of
-   the specific JxBrowser version in
-   the [release notes](https://teamdev.com/jxbrowser/release-notes/) of the
-   last, or in one of the previous version where Chromium has been updated.
+   will not be able to connect to Chromium. You can find which Chromium version
+   is used in the specific JxBrowser version in
+   the [release notes](https://teamdev.com/jxbrowser/release-notes/).
 2. [Insert your license key](https://teamdev.com/jxbrowser/docs/guides/introduction/licensing/#adding-the-license-to-a-project)
-   into [the test application](./target-app/src/main/java/TargetApp.java).
+   into [the test application](./target-app/src/main/java/App.java).
 3. In the [root](../..) directory, run the `buildApplication` task
    of the [target-app](target-app) module to create an executable file for the
    current platform that later will be run by Selenium WebDriver.

--- a/tutorials/selenium/README.md
+++ b/tutorials/selenium/README.md
@@ -19,7 +19,7 @@ the [tutorial](https://jxbrowser-support.teamdev.com/docs/tutorials/integration/
    to create an executable file for the current platform that later will be
    run by Selenium WebDriver.
    ```bash
-   gradlew buildApplication
+   gradlew clean buildApplication
    ```
 4. Run [Selenium](launcher/src/main/java/SeleniumLauncher.java).
 5. If everything configured properly, you will see the launched test

--- a/tutorials/selenium/README.md
+++ b/tutorials/selenium/README.md
@@ -7,20 +7,52 @@ JxBrowser.
 Creating of these example projects is described in
 the [tutorial](https://jxbrowser-support.teamdev.com/docs/tutorials/integration/selenium.html).
 
+The tutorial is available on all supported platforms.
+
+## Prerequisites
+
+The tutorial requires the `jpackage` tool available in `PATH` so make sure that
+the environment variable contains the `%JAVA_HOME%/bin` directory.
+
 ## Building and Launching
 
-1. In the [launcher](launcher) module, run the `downloadChromeDriver` task 
-   to download ChromeDriver to the `resources` directory:
+1. In the [root](../..) directory, run the `downloadChromeDriver` task of
+   the [launcher](launcher) module to download ChromeDriver to the
+   `resources` directory:
+   
+   **Windows:**
    ```bash
-   gradlew downloadChromeDriver
+   gradlew launcher:downloadChromeDriver
    ```
-2. [Insert your license key](https://teamdev.com/jxbrowser/docs/guides/introduction/licensing/#adding-the-license-to-a-project) into [the test application](./target-app/src/main/java/TargetApp.java).
-3. In the [target-app](target-app) module, run the `buildApplication` task
-   to create an executable file for the current platform that later will be
-   run by Selenium WebDriver.
+   
+   **macOS/Linux:**
+     ```bash
+   ./gradlew launcher:downloadChromeDriver
+   ```
+
+   > **_NOTE:_** Each version of ChromeDriver corresponds to the same version of
+   Chromium used in JxBrowser. So if you change the JxBrowser version in the
+   root [build.gradle.kts](../../build.gradle.kts) you need to update the
+   `chromiumVersion` property [here](launcher/build.gradle.kts)
+   before running the `downloadChromeDriver` task. Otherwise, Selenium WebDriver
+   will not be able to connect to Chromium. You can find a list of
+   Chromium-to-JxBrowser versions
+   [here](https://teamdev.com/jxbrowser/docs/guides/introduction/licensing/#chromium-open-source-components%E2%80%99-licenses)
+2. [Insert your license key](https://teamdev.com/jxbrowser/docs/guides/introduction/licensing/#adding-the-license-to-a-project)
+   into [the test application](./target-app/src/main/java/TargetApp.java).
+3. In the [root](../..) directory, run the `buildApplication` task
+   of the [target-app](target-app) module to create an executable file for the
+   current platform that later will be run by Selenium WebDriver.
+
+   **Windows:**
    ```bash
-   gradlew clean buildApplication
+   gradlew target-app:clean target-app:buildApplication
    ```
+   **macOS/Linux:**
+   ```bash
+   ./gradlew target-app:clean target-app:buildApplication
+   ```
+   
 4. Run [Selenium](launcher/src/main/java/SeleniumLauncher.java).
 5. If everything configured properly, you will see the launched test
    application, and the following in the console output:

--- a/tutorials/selenium/README.md
+++ b/tutorials/selenium/README.md
@@ -1,28 +1,34 @@
 # JxBrowser and Selenium WebDriver
 
-This tutorial demonstrates how to create a simple Selenium WebDriver application that is configured
-to access a web page loaded in a desktop Java app using JxBrowser on Windows.
+This tutorial demonstrates how to create a simple Selenium WebDriver application
+that is configured to access a web page in a desktop Java application based on
+JxBrowser.
 
 Creating of these example projects is described in
 the [tutorial](https://jxbrowser-support.teamdev.com/docs/tutorials/integration/selenium.html).
 
 ## Building and Launching
 
-1. Download [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads). Put it
-   into the `launcher/src/main/resources` directory. Use one of the latest versions.
-2. [Insert your license key](https://jxbrowser-support.teamdev.com/docs/guides/licensing.html#adding-the-license-to-a-project)
-   into [the test application](https://github.com/TeamDev-IP/JxBrowser-Examples/blob/90fdd92f7c4c8737929f57e0383aad39d4be2aee/tutorials/selenium/target-app/src/main/java/TargetApp.java#L45)
-   .
-3. In the [target-app](target-app) module run the `createExe` Gradle task.
+1. In the [launcher](launcher) module, run the `downloadChromeDriver` task 
+   to download ChromeDriver to the `resources` directory:
+   ```bash
+   gradlew downloadChromeDriver
+   ```
+2. [Insert your license key](https://teamdev.com/jxbrowser/docs/guides/introduction/licensing/#adding-the-license-to-a-project) into [the test application](./target-app/src/main/java/TargetApp.java).
+3. In the [target-app](target-app) module, run the `buildApplication` task
+   to create an executable file for the current platform that later will be
+   run by Selenium WebDriver.
+   ```bash
+   gradlew buildApplication
+   ```
 4. Run [Selenium](launcher/src/main/java/SeleniumLauncher.java).
-
-   _You may need to run Selenium twice as during the first start ChromeDriver may not detect the
-   running application binaries._
-
-5. If everything configured properly, you will see the launched test application, and the following
-   in the console output:
+5. If everything configured properly, you will see the launched test
+   application, and the following in the console output:
    ```
-   Current URL: https://www.google.com/
+   Current URL: about:blank
+   // or
+   Current URL: https://www.google.com/ 
    ```
-   It means that Selenium WebDriver managed to successfully run the application, set up a connection
-   with the JxBrowser's Chromium engine, and access the loaded web page to print its URL.
+   It means that Selenium WebDriver managed to successfully run the application,
+   set up a connection with the JxBrowser's Chromium, and access the loaded
+   web page to print its URL.

--- a/tutorials/selenium/launcher/build.gradle.kts
+++ b/tutorials/selenium/launcher/build.gradle.kts
@@ -67,6 +67,9 @@ tasks.register("downloadChromeDriver") {
     val downloadUrl =
         "https://storage.googleapis.com/chrome-for-testing-public/$chromiumVersion/$chromeDriverPlatform/chromedriver-$chromeDriverPlatform.zip"
     val resourcesDir = sourceSets["main"].resources.srcDirs.first()
+    if (!resourcesDir.exists()) {
+        mkdir(resourcesDir)
+    }
     val chromeDriverZip = resourcesDir.resolve("chromedriver.zip")
     val chromeDriver = resourcesDir.resolve("chromedriver")
 
@@ -89,8 +92,9 @@ tasks.register("downloadChromeDriver") {
                             }
                         }
                         val extension = outputFile.extension
-                        if (extension.endsWith("exe") ||
-                            extension.isEmpty()) {
+                        if (extension.isEmpty() &&
+                            !System.getProperty("os.name").startsWith("Windows")
+                        ) {
                             Files.setPosixFilePermissions(
                                 outputFile.toPath(),
                                 EnumSet.of(

--- a/tutorials/selenium/launcher/build.gradle.kts
+++ b/tutorials/selenium/launcher/build.gradle.kts
@@ -1,3 +1,11 @@
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermission.*
+import java.util.*
+import java.util.zip.ZipFile
+
 /*
  *  Copyright 2024, TeamDev. All rights reserved.
  *
@@ -19,5 +27,86 @@
  */
 
 dependencies {
-    implementation(group = "org.seleniumhq.selenium", name = "selenium-chrome-driver", version = "3.141.59")
+    implementation("org.seleniumhq.selenium:selenium-chrome-driver:4.26.0")
+}
+
+// The Chromium version used in JxBrowser.
+val chromiumVersion = "130.0.6723.70"
+
+fun chromedriverPlatform(): String {
+    fun isArm(): Boolean {
+        val arch = System.getProperty("os.arch")
+        return "aarch64" == arch || "arm" == arch
+    }
+
+    val os = System.getProperty("os.name")
+    return when {
+        os.startsWith("Windows") -> {
+            "win64"
+        }
+
+        os.startsWith("Linux") -> {
+            "linux64"
+        }
+
+        os.startsWith("Mac") -> {
+            if (isArm()) {
+                "mac-arm64"
+            } else {
+                "mac-x64"
+            }
+        }
+
+        else -> {
+            throw IllegalStateException("Unsupported operating system.")
+        }
+    }
+}
+
+tasks.register("downloadChromedriver") {
+    val chromeDriverPlatform = chromedriverPlatform()
+    val downloadUrl =
+        "https://storage.googleapis.com/chrome-for-testing-public/$chromiumVersion/$chromeDriverPlatform/chromedriver-$chromeDriverPlatform.zip"
+    val resourcesDir = sourceSets["main"].resources.srcDirs.first()
+    val chromedriverZip = resourcesDir.resolve("chromedriver.zip")
+    val chromedriver = resourcesDir.resolve("chromedriver")
+
+    doLast {
+        URL(downloadUrl).openStream().use { inputStream ->
+            Files.copy(
+                inputStream,
+                chromedriverZip.toPath(),
+                StandardCopyOption.REPLACE_EXISTING
+            )
+            println("Chromedriver downloaded to ${chromedriverZip.absolutePath}")
+            ZipFile(chromedriverZip).use { zip ->
+                zip.entries().asSequence().forEach { entry ->
+                    if (!entry.isDirectory) {
+                        val outputFile =
+                            File(resourcesDir, File(entry.name).name)
+                        zip.getInputStream(entry).use { input ->
+                            outputFile.outputStream().use { output ->
+                                input.copyTo(output)
+                            }
+                        }
+                        val extension = outputFile.extension
+                        if (extension.endsWith("exe") ||
+                            extension.isEmpty()) {
+                            Files.setPosixFilePermissions(
+                                outputFile.toPath(),
+                                EnumSet.of(
+                                    OWNER_EXECUTE,
+                                    OWNER_READ,
+                                    GROUP_EXECUTE,
+                                    GROUP_READ
+                                )
+                            )
+                        }
+                    }
+                }
+                println("Chromedriver extracted to ${chromedriver.absolutePath}")
+            }
+            delete(chromedriverZip)
+        }
+    }
 }

--- a/tutorials/selenium/launcher/build.gradle.kts
+++ b/tutorials/selenium/launcher/build.gradle.kts
@@ -100,8 +100,10 @@ tasks.register("downloadChromeDriver") {
                                 EnumSet.of(
                                     OWNER_EXECUTE,
                                     OWNER_READ,
+                                    OWNER_WRITE,
                                     GROUP_EXECUTE,
-                                    GROUP_READ
+                                    GROUP_READ,
+                                    GROUP_WRITE
                                 )
                             )
                         }

--- a/tutorials/selenium/launcher/build.gradle.kts
+++ b/tutorials/selenium/launcher/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 // The Chromium version used in JxBrowser.
 val chromiumVersion = "130.0.6723.70"
 
-fun chromedriverPlatform(): String {
+fun chromeDriverPlatform(): String {
     fun isArm(): Boolean {
         val arch = System.getProperty("os.arch")
         return "aarch64" == arch || "arm" == arch
@@ -63,7 +63,7 @@ fun chromedriverPlatform(): String {
 }
 
 tasks.register("downloadChromeDriver") {
-    val chromeDriverPlatform = chromedriverPlatform()
+    val chromeDriverPlatform = chromeDriverPlatform()
     val downloadUrl =
         "https://storage.googleapis.com/chrome-for-testing-public/$chromiumVersion/$chromeDriverPlatform/chromedriver-$chromeDriverPlatform.zip"
     val resourcesDir = sourceSets["main"].resources.srcDirs.first()

--- a/tutorials/selenium/launcher/build.gradle.kts
+++ b/tutorials/selenium/launcher/build.gradle.kts
@@ -1,7 +1,6 @@
 import java.net.URL
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.attribute.PosixFilePermission.*
 import java.util.*
 import java.util.zip.ZipFile
@@ -63,23 +62,23 @@ fun chromedriverPlatform(): String {
     }
 }
 
-tasks.register("downloadChromedriver") {
+tasks.register("downloadChromeDriver") {
     val chromeDriverPlatform = chromedriverPlatform()
     val downloadUrl =
         "https://storage.googleapis.com/chrome-for-testing-public/$chromiumVersion/$chromeDriverPlatform/chromedriver-$chromeDriverPlatform.zip"
     val resourcesDir = sourceSets["main"].resources.srcDirs.first()
-    val chromedriverZip = resourcesDir.resolve("chromedriver.zip")
-    val chromedriver = resourcesDir.resolve("chromedriver")
+    val chromeDriverZip = resourcesDir.resolve("chromedriver.zip")
+    val chromeDriver = resourcesDir.resolve("chromedriver")
 
     doLast {
         URL(downloadUrl).openStream().use { inputStream ->
             Files.copy(
                 inputStream,
-                chromedriverZip.toPath(),
+                chromeDriverZip.toPath(),
                 StandardCopyOption.REPLACE_EXISTING
             )
-            println("Chromedriver downloaded to ${chromedriverZip.absolutePath}")
-            ZipFile(chromedriverZip).use { zip ->
+            println("ChromeDriver downloaded to ${chromeDriverZip.absolutePath}")
+            ZipFile(chromeDriverZip).use { zip ->
                 zip.entries().asSequence().forEach { entry ->
                     if (!entry.isDirectory) {
                         val outputFile =
@@ -104,9 +103,9 @@ tasks.register("downloadChromedriver") {
                         }
                     }
                 }
-                println("Chromedriver extracted to ${chromedriver.absolutePath}")
+                println("ChromeDriver extracted to ${chromeDriver.absolutePath}")
             }
-            delete(chromedriverZip)
+            delete(chromeDriverZip)
         }
     }
 }

--- a/tutorials/selenium/launcher/build.gradle.kts
+++ b/tutorials/selenium/launcher/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     implementation("org.seleniumhq.selenium:selenium-chrome-driver:4.26.0")
 }
 
-// The Chromium version used in JxBrowser.
+// The Chromium version used in JxBrowser 8.1.0.
 val chromiumVersion = "130.0.6723.70"
 
 fun chromeDriverPlatform(): String {

--- a/tutorials/selenium/launcher/src/main/java/SeleniumLauncher.java
+++ b/tutorials/selenium/launcher/src/main/java/SeleniumLauncher.java
@@ -18,28 +18,32 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.teamdev.jxbrowser.os.Environment.isMac;
+import static com.teamdev.jxbrowser.os.Environment.isWindows;
+import static java.util.Objects.requireNonNull;
+
 import java.io.File;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
 /**
- * An application that configures Selenium WebDriver (ChromeDriver) to run on the JxBrowser-based
- * application binaries and get access to HTML content loaded in JxBrowser.
+ * An application that configures Selenium WebDriver (ChromeDriver) to run on
+ * the JxBrowser-based application binaries and get access to HTML content
+ * loaded in JxBrowser.
  */
 public final class SeleniumLauncher {
 
     public static void main(String[] args) {
         // Set a path to the ChromeDriver executable.
-        System.setProperty("webdriver.chrome.driver",
-                "tutorials/selenium/launcher/src/main/resources/chromedriver.exe");
+        System.setProperty("webdriver.chrome.driver", requireNonNull(
+                SeleniumLauncher.class.getResource(chromeDriverFile())).getPath());
 
         // #docfragment "path-to-exe"
         ChromeOptions options = new ChromeOptions();
 
         // Set a path to your JxBrowser application executable.
-        options.setBinary(
-                new File("tutorials/selenium/target-app/build/executable/TargetApp.exe"));
+        options.setBinary(new File(binaryPath()));
         // #enddocfragment "path-to-exe"
         // #docfragment "set-remote-debugging-port"
         // Set a port to communicate on.
@@ -52,5 +56,25 @@ public final class SeleniumLauncher {
         System.out.printf("Current URL: %s\n", driver.getCurrentUrl());
 
         driver.quit();
+    }
+
+    private static String binaryPath() {
+        var applicationDirectory =
+                "tutorials/selenium/target-app/build/application/";
+        if (isMac()) {
+            return applicationDirectory
+                    + "TargetApp.app/Contents/MacOS/TargetApp";
+        } else if (isWindows()) {
+            return applicationDirectory + "TargetApp.exe";
+        }
+
+        throw new IllegalStateException("The platform is unsupported.");
+    }
+
+    private static String chromeDriverFile() {
+        if (isWindows()) {
+            return "chromedriver.exe";
+        }
+        return "chromedriver";
     }
 }

--- a/tutorials/selenium/launcher/src/main/java/SeleniumLauncher.java
+++ b/tutorials/selenium/launcher/src/main/java/SeleniumLauncher.java
@@ -23,7 +23,9 @@ import static com.teamdev.jxbrowser.os.Environment.isWindows;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import org.openqa.selenium.WebDriver;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
@@ -34,13 +36,15 @@ import org.openqa.selenium.chrome.ChromeOptions;
  */
 public final class SeleniumLauncher {
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws URISyntaxException {
+        URL chromeDriverUrl = requireNonNull(
+                SeleniumLauncher.class.getResource(chromeDriverFile()));
         // Set a path to the ChromeDriver executable.
-        System.setProperty("webdriver.chrome.driver", requireNonNull(
-                SeleniumLauncher.class.getResource(chromeDriverFile())).getPath());
+        System.setProperty("webdriver.chrome.driver",
+                Paths.get(chromeDriverUrl.toURI()).toString());
 
         // #docfragment "path-to-exe"
-        ChromeOptions options = new ChromeOptions();
+        var options = new ChromeOptions();
 
         // Set a path to your JxBrowser application executable.
         options.setBinary(new File(binaryPath()));
@@ -50,7 +54,7 @@ public final class SeleniumLauncher {
         options.addArguments("--remote-debugging-port=9222");
         // #enddocfragment "set-remote-debugging-port"
 
-        WebDriver driver = new ChromeDriver(options);
+        var driver = new ChromeDriver(options);
 
         // Now you can use WebDriver.
         System.out.printf("Current URL: %s\n", driver.getCurrentUrl());
@@ -65,7 +69,7 @@ public final class SeleniumLauncher {
             return applicationDirectory
                     + "TargetApp.app/Contents/MacOS/TargetApp";
         } else if (isWindows()) {
-            return applicationDirectory + "TargetApp.exe";
+            return applicationDirectory + "TargetApp/TargetApp.exe";
         }
 
         throw new IllegalStateException("The platform is unsupported.");

--- a/tutorials/selenium/launcher/src/main/java/SeleniumLauncher.java
+++ b/tutorials/selenium/launcher/src/main/java/SeleniumLauncher.java
@@ -31,9 +31,8 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
 /**
- * An application that configures Selenium WebDriver (ChromeDriver) to run on
- * the JxBrowser-based application binaries and get access to HTML content
- * loaded in JxBrowser.
+ * Configures Selenium WebDriver (ChromeDriver) to run the JxBrowser-based
+ * application and get access to the loaded web page.
  */
 public final class SeleniumLauncher {
 
@@ -68,11 +67,11 @@ public final class SeleniumLauncher {
                 "tutorials/selenium/target-app/build/application/";
         if (isMac()) {
             return applicationDirectory
-                    + "TargetApp.app/Contents/MacOS/TargetApp";
+                    + "App.app/Contents/MacOS/App";
         } else if (isWindows()) {
-            return applicationDirectory + "TargetApp/TargetApp.exe";
+            return applicationDirectory + "App/App.exe";
         } else if (isLinux()) {
-            return applicationDirectory + "TargetApp/bin/TargetApp";
+            return applicationDirectory + "App/bin/App";
         }
 
         throw new IllegalStateException("The platform is unsupported.");

--- a/tutorials/selenium/launcher/src/main/java/SeleniumLauncher.java
+++ b/tutorials/selenium/launcher/src/main/java/SeleniumLauncher.java
@@ -18,6 +18,7 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import static com.teamdev.jxbrowser.os.Environment.isLinux;
 import static com.teamdev.jxbrowser.os.Environment.isMac;
 import static com.teamdev.jxbrowser.os.Environment.isWindows;
 import static java.util.Objects.requireNonNull;
@@ -70,6 +71,8 @@ public final class SeleniumLauncher {
                     + "TargetApp.app/Contents/MacOS/TargetApp";
         } else if (isWindows()) {
             return applicationDirectory + "TargetApp/TargetApp.exe";
+        } else if (isLinux()) {
+            return applicationDirectory + "TargetApp/bin/TargetApp";
         }
 
         throw new IllegalStateException("The platform is unsupported.");

--- a/tutorials/selenium/target-app/build.gradle.kts
+++ b/tutorials/selenium/target-app/build.gradle.kts
@@ -18,12 +18,12 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val mainJar = "targetApp.jar"
+val mainJar = "app.jar"
 
 tasks.jar {
     archiveFileName.set(mainJar)
     manifest {
-        attributes["Main-Class"] = "TargetApp"
+        attributes["Main-Class"] = "App"
     }
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from({
@@ -41,10 +41,10 @@ tasks.register<Exec>("buildApplication") {
         "jpackage",
         "--input", "./build/libs",
         "--main-jar", mainJar,
-        "--name", "TargetApp",
+        "--name", "App",
         "--app-version", version,
         "--type", "app-image",
-        "--main-class", "TargetApp",
+        "--main-class", "App",
         "--dest", "./build/application",
     )
 }

--- a/tutorials/selenium/target-app/build.gradle.kts
+++ b/tutorials/selenium/target-app/build.gradle.kts
@@ -18,12 +18,33 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-plugins {
-    id("edu.sc.seis.launch4j") version "3.0.4"
+val mainJar = "targetApp.jar"
+
+tasks.jar {
+    archiveFileName.set(mainJar)
+    manifest {
+        attributes["Main-Class"] = "TargetApp"
+    }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    from({
+        configurations.runtimeClasspath.get().map {
+            if (it.isDirectory) it else zipTree(it)
+        }
+    })
+    exclude("META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA")
 }
 
-launch4j {
-    outfile = "TargetApp.exe"
-    mainClassName = "TargetApp"
-    outputDir = "executable"
+tasks.register<Exec>("buildExecutable") {
+    dependsOn(tasks.build)
+
+    commandLine(
+        "jpackage",
+        "--input", "./build/libs",
+        "--main-jar", mainJar,
+        "--name", "TargetApp",
+        "--app-version", version,
+        "--type", "app-image",
+        "--main-class", "TargetApp",
+        "--dest", "./build/application",
+    )
 }

--- a/tutorials/selenium/target-app/build.gradle.kts
+++ b/tutorials/selenium/target-app/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.jar {
     exclude("META-INF/*.RSA", "META-INF/*.SF", "META-INF/*.DSA")
 }
 
-tasks.register<Exec>("buildExecutable") {
+tasks.register<Exec>("buildApplication") {
     dependsOn(tasks.build)
 
     commandLine(

--- a/tutorials/selenium/target-app/src/main/java/App.java
+++ b/tutorials/selenium/target-app/src/main/java/App.java
@@ -36,7 +36,7 @@ import javax.swing.WindowConstants;
  * BrowserView, and connect JxBrowser's Chromium engine with Selenium via the remote debugging port
  * obtained from the command line.
  */
-public final class TargetApp {
+public final class App {
 
     private static final String REMOTE_DEBUGGING_PORT_ARG = "--remote-debugging-port=";
 

--- a/tutorials/selenium/target-app/src/main/java/App.java
+++ b/tutorials/selenium/target-app/src/main/java/App.java
@@ -32,9 +32,9 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to create a simple Swing application with a web page loaded in
- * BrowserView, and connect JxBrowser's Chromium engine with Selenium via the remote debugging port
- * obtained from the command line.
+ * A simple Swing application with a web page loaded in {@code BrowserView} that
+ * will be run by Selenium WebDriver later on and debugged via the remote
+ * debugging port obtained from the command line.
  */
 public final class App {
 
@@ -49,7 +49,8 @@ public final class App {
         var builder = EngineOptions.newBuilder(HARDWARE_ACCELERATED);
 
         // Configure Engine with the remote debugging port obtained from the command line args.
-        remoteDebuggingPortFromCommandLine(args).ifPresent(builder::remoteDebuggingPort);
+        remoteDebuggingPortFromCommandLine(args).ifPresent(
+                builder::remoteDebuggingPort);
         // #enddocfragment "forward-remote-debugging-port"
 
         // Creating Chromium engine.
@@ -80,11 +81,13 @@ public final class App {
     }
 
     // #docfragment "get-remote-debugging-port"
-    private static Optional<Integer> remoteDebuggingPortFromCommandLine(String[] args) {
+    private static Optional<Integer> remoteDebuggingPortFromCommandLine(
+            String[] args) {
         if (args.length > 0) {
             for (var arg : args) {
                 if (arg.startsWith(REMOTE_DEBUGGING_PORT_ARG)) {
-                    var port = arg.substring(REMOTE_DEBUGGING_PORT_ARG.length());
+                    var port = arg.substring(
+                            REMOTE_DEBUGGING_PORT_ARG.length());
                     return Optional.of(Integer.parseInt(port));
                 }
             }

--- a/tutorials/selenium/target-app/src/main/java/TargetApp.java
+++ b/tutorials/selenium/target-app/src/main/java/TargetApp.java
@@ -20,7 +20,6 @@
 
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
 
-import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.engine.EngineOptions;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
@@ -47,23 +46,23 @@ public final class TargetApp {
 
         // #docfragment "forward-remote-debugging-port"
         // Create a builder for EngineOptions.
-        EngineOptions.Builder builder = EngineOptions.newBuilder(HARDWARE_ACCELERATED);
+        var builder = EngineOptions.newBuilder(HARDWARE_ACCELERATED);
 
         // Configure Engine with the remote debugging port obtained from the command line args.
         remoteDebuggingPortFromCommandLine(args).ifPresent(builder::remoteDebuggingPort);
         // #enddocfragment "forward-remote-debugging-port"
 
         // Creating Chromium engine.
-        Engine engine = Engine.newInstance(builder.build());
-        Browser browser = engine.newBrowser();
+        var engine = Engine.newInstance(builder.build());
+        var browser = engine.newBrowser();
 
         SwingUtilities.invokeLater(() -> {
             // Creating Swing component for rendering web content
             // loaded in the given Browser instance.
-            BrowserView view = BrowserView.newInstance(browser);
+            var view = BrowserView.newInstance(browser);
 
             // Creating and displaying Swing app frame.
-            JFrame frame = new JFrame();
+            var frame = new JFrame();
             frame.addWindowListener(new WindowAdapter() {
                 @Override
                 public void windowClosing(WindowEvent e) {
@@ -83,9 +82,9 @@ public final class TargetApp {
     // #docfragment "get-remote-debugging-port"
     private static Optional<Integer> remoteDebuggingPortFromCommandLine(String[] args) {
         if (args.length > 0) {
-            for (String arg : args) {
+            for (var arg : args) {
                 if (arg.startsWith(REMOTE_DEBUGGING_PORT_ARG)) {
-                    String port = arg.substring(REMOTE_DEBUGGING_PORT_ARG.length());
+                    var port = arg.substring(REMOTE_DEBUGGING_PORT_ARG.length());
                     return Optional.of(Integer.parseInt(port));
                 }
             }


### PR DESCRIPTION
A part of https://github.com/TeamDev-IP/JxBrowser-Docs/issues/261

In this changeset, we update our selenium tutorial, particularly:

- Made it run also on Linux and macOS
- Updated Selenium WebDriver dependency
- Created a Gradle task to automatically download ChromeDriver for the current platform and JxBrowser version.
**Note:** We will need to keep the `chromiumVersion` field up-to-date with the current version of Chromium in JxBrowser. Since we have the automated script for updating the JxBrowser version in examples, I think it will not be a problem.
- Switched from `launch4j` to `jpackage` to be able to build the target application for 3 platforms
- Updated README so now it is more straightforward and not confusing.
- Moved local variables to `var`