### PR TITLE
Add tutorial demonstrating how to take a screenshot of the web page

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,7 +43,7 @@ module("web-crawler", "./tutorials/web-crawler")
 module("media-player", "./tutorials/media-player")
 // JxBrowser logs redirection
 module("jul-logs-redirect", "./tutorials/jul-logs-redirect")
-module("taking-screenshots", "./tutorials/taking-screenshots")
+module("html2png", "./tutorials/html2png")
 module("serve-from-directory", "./tutorials/serve-from-directory")
 module("js-java", "./tutorials/js-java")
 module("crx-extensions", "./tutorials/crx-extensions")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ module("web-crawler", "./tutorials/web-crawler")
 module("media-player", "./tutorials/media-player")
 // JxBrowser logs redirection
 module("jul-logs-redirect", "./tutorials/jul-logs-redirect")
+module("taking-screenshots", "./tutorials/taking-screenshots")
 module("serve-from-directory", "./tutorials/serve-from-directory")
 module("js-java", "./tutorials/js-java")
 module("crx-extensions", "./tutorials/crx-extensions")

--- a/tutorials/html2png/src/main/java/com/teamdev/jxbrowser/examples/html2png/Html2Png.java
+++ b/tutorials/html2png/src/main/java/com/teamdev/jxbrowser/examples/html2png/Html2Png.java
@@ -18,9 +18,7 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.teamdev.jxbrowser.examples.screenshot;
-
-import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
+package com.teamdev.jxbrowser.examples.html2png;import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
 
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.graphics.BitmapImage;
@@ -32,7 +30,7 @@ import javax.imageio.ImageIO;
  * This example demonstrates how to take a screenshot of the whole web page,
  * including the part that is not visible on the screen.
  */
-public final class WebPageScreenshot {
+public final class Html2Png {
 
     private static final int PAGE_RENDER_TIMEOUT_MS = 500;
 

--- a/tutorials/html2png/src/main/java/com/teamdev/jxbrowser/examples/html2png/Html2Png.java
+++ b/tutorials/html2png/src/main/java/com/teamdev/jxbrowser/examples/html2png/Html2Png.java
@@ -41,8 +41,7 @@ public final class Html2Png {
             var browser = engine.newBrowser();
 
             // Load the required web page.
-            browser.navigation()
-                    .loadUrlAndWait("https://html5test.teamdev.com/");
+            browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
 
             // Wait until the web page has been rendered completely.
             Thread.sleep(PAGE_RENDER_TIMEOUT_MS);
@@ -53,19 +52,15 @@ public final class Html2Png {
             // including the invisible part.
             Double pageHeight = frame.executeJavaScript(
                     "Math.max(document.body.scrollHeight, " +
-                            "document.documentElement.scrollHeight, document.body.offsetHeight, "
-                            +
-                            "document.documentElement.offsetHeight, document.body.clientHeight, "
-                            +
+                            "document.documentElement.scrollHeight, document.body.offsetHeight, " +
+                            "document.documentElement.offsetHeight, document.body.clientHeight, " +
                             "document.documentElement.clientHeight);");
 
             // Get the width of the loaded page.
             Double pageWidth = frame.executeJavaScript(
                     "Math.max(document.body.scrollWidth, " +
-                            "document.documentElement.scrollWidth, document.body.offsetWidth, "
-                            +
-                            "document.documentElement.offsetWidth, document.body.clientWidth, "
-                            +
+                            "document.documentElement.scrollWidth, document.body.offsetWidth, " +
+                            "document.documentElement.offsetWidth, document.body.clientWidth, " +
                             "document.documentElement.clientWidth);");
 
             // Resize the browser to the obtained dimensions.

--- a/tutorials/html2png/src/main/java/com/teamdev/jxbrowser/examples/html2png/Html2Png.java
+++ b/tutorials/html2png/src/main/java/com/teamdev/jxbrowser/examples/html2png/Html2Png.java
@@ -18,7 +18,9 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package com.teamdev.jxbrowser.examples.html2png;import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
+package com.teamdev.jxbrowser.examples.html2png;
+
+import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
 
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.graphics.BitmapImage;
@@ -39,7 +41,8 @@ public final class Html2Png {
             var browser = engine.newBrowser();
 
             // Load the required web page.
-            browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
+            browser.navigation()
+                    .loadUrlAndWait("https://html5test.teamdev.com/");
 
             // Wait until the web page has been rendered completely.
             Thread.sleep(PAGE_RENDER_TIMEOUT_MS);
@@ -50,15 +53,19 @@ public final class Html2Png {
             // including the invisible part.
             Double pageHeight = frame.executeJavaScript(
                     "Math.max(document.body.scrollHeight, " +
-                            "document.documentElement.scrollHeight, document.body.offsetHeight, " +
-                            "document.documentElement.offsetHeight, document.body.clientHeight, " +
+                            "document.documentElement.scrollHeight, document.body.offsetHeight, "
+                            +
+                            "document.documentElement.offsetHeight, document.body.clientHeight, "
+                            +
                             "document.documentElement.clientHeight);");
 
             // Get the width of the loaded page.
             Double pageWidth = frame.executeJavaScript(
                     "Math.max(document.body.scrollWidth, " +
-                            "document.documentElement.scrollWidth, document.body.offsetWidth, " +
-                            "document.documentElement.offsetWidth, document.body.clientWidth, " +
+                            "document.documentElement.scrollWidth, document.body.offsetWidth, "
+                            +
+                            "document.documentElement.offsetWidth, document.body.clientWidth, "
+                            +
                             "document.documentElement.clientWidth);");
 
             // Resize the browser to the obtained dimensions.

--- a/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
+++ b/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
@@ -33,7 +33,7 @@ import javax.imageio.ImageIO;
  */
 public final class WebPageScreenshot {
 
-    private static final int PAGE_RENDER_TIMEOUT_MS = 200;
+    private static final int PAGE_RENDER_TIMEOUT_MS = 500;
 
     public static void main(String[] args) throws IOException {
         try (var engine = Engine.newInstance(OFF_SCREEN)) {

--- a/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
+++ b/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
@@ -38,15 +38,17 @@ public final class WebPageScreenshot {
     public static void main(String[] args) throws IOException {
         try (var engine = Engine.newInstance(OFF_SCREEN)) {
             var browser = engine.newBrowser();
-            var frame = browser.mainFrame().orElseThrow();
 
             // Load the required web page.
             browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
 
-            // Wait until the web page has been rendered completely.
-            Thread.sleep(PAGE_RENDER_TIMEOUT);
+            var frame = browser.mainFrame().orElseThrow();
 
-            // Get the height of the loaded page.
+            // Wait until the web page has been rendered completely.
+            Thread.sleep(PAGE_RENDER_TIMEOUT_MS);
+
+            // Get the height of the whole web page,
+            // including the invisible part.
             Double pageHeight = frame.executeJavaScript(
                     "Math.max(document.body.scrollHeight, " +
                             "document.documentElement.scrollHeight, document.body.offsetHeight, " +
@@ -63,6 +65,8 @@ public final class WebPageScreenshot {
             // Resize the browser to the obtained dimensions.
             browser.resize(pageWidth.intValue(), pageHeight.intValue());
 
+            // Obtain the bitmap of the currently loaded web page,
+            // including the invisible part.
             var bitmap = browser.bitmap();
 
             // Convert the bitmap to image.

--- a/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
+++ b/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
@@ -60,7 +60,7 @@ public final class WebPageScreenshot {
                             "document.documentElement.offsetWidth, document.body.clientWidth, " +
                             "document.documentElement.clientWidth);");
 
-            // Resize browser to the obtained dimensions.
+            // Resize the browser to the obtained dimensions.
             browser.resize(pageWidth.intValue(), pageHeight.intValue());
 
             var bitmap = browser.bitmap();

--- a/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
+++ b/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
@@ -42,10 +42,10 @@ public final class WebPageScreenshot {
             // Load the required web page.
             browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
 
-            var frame = browser.mainFrame().orElseThrow();
-
             // Wait until the web page has been rendered completely.
             Thread.sleep(PAGE_RENDER_TIMEOUT_MS);
+
+            var frame = browser.mainFrame().orElseThrow();
 
             // Get the height of the whole web page,
             // including the invisible part.

--- a/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
+++ b/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
@@ -33,7 +33,7 @@ import javax.imageio.ImageIO;
  */
 public final class WebPageScreenshot {
 
-    private static final int PAGE_RENDER_TIMEOUT = 200;
+    private static final int PAGE_RENDER_TIMEOUT_MS = 200;
 
     public static void main(String[] args) throws IOException {
         try (var engine = Engine.newInstance(OFF_SCREEN)) {

--- a/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
+++ b/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2024, TeamDev. All rights reserved.
+ *
+ *  Redistribution and use in source and/or binary forms, with or without
+ *  modification, must retain the above copyright notice and the following
+ *  disclaimer.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ *  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ *  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ *  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ *  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ *  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.teamdev.jxbrowser.examples.screenshot;
+
+import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
+
+import com.teamdev.jxbrowser.engine.Engine;
+import com.teamdev.jxbrowser.view.swing.graphics.BitmapImage;
+import java.io.File;
+import java.io.IOException;
+import javax.imageio.ImageIO;
+
+/**
+ * This example demonstrates how to take the screenshot of the web page.
+ */
+public final class WebPageScreenshot {
+
+    private static final int PAGE_RENDER_TIMEOUT = 200;
+
+    public static void main(String[] args) throws IOException {
+        try (var engine = Engine.newInstance(OFF_SCREEN)) {
+            var browser = engine.newBrowser();
+            var frame = browser.mainFrame().orElseThrow();
+
+            // Load the required web page.
+            browser.navigation().loadUrlAndWait("https://html5test.teamdev.com/");
+
+            // Wait until the web page has been rendered completely.
+            Thread.sleep(PAGE_RENDER_TIMEOUT);
+
+            // Get the height of the loaded page.
+            Double pageHeight = frame.executeJavaScript(
+                    "Math.max(document.body.scrollHeight, " +
+                            "document.documentElement.scrollHeight, document.body.offsetHeight, " +
+                            "document.documentElement.offsetHeight, document.body.clientHeight, " +
+                            "document.documentElement.clientHeight);");
+
+            // Get the width of the loaded page.
+            Double pageWidth = frame.executeJavaScript(
+                    "Math.max(document.body.scrollWidth, " +
+                            "document.documentElement.scrollWidth, document.body.offsetWidth, " +
+                            "document.documentElement.offsetWidth, document.body.clientWidth, " +
+                            "document.documentElement.clientWidth);");
+
+            // Resize browser to the obtained dimensions.
+            browser.resize(pageWidth.intValue(), pageHeight.intValue());
+
+            var bitmap = browser.bitmap();
+
+            // Convert the bitmap to image.
+            var image = BitmapImage.toToolkit(bitmap);
+
+            // Save the image to a PNG file.
+            ImageIO.write(image, "PNG", new File("bitmap.png"));
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
+++ b/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
@@ -29,7 +29,8 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 
 /**
- * This example demonstrates how to take a screenshot of the whole web page including the part that is not visible on the screen.
+ * This example demonstrates how to take a screenshot of the whole web page,
+ * including the part that is not visible on the screen.
  */
 public final class WebPageScreenshot {
 

--- a/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
+++ b/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import javax.imageio.ImageIO;
 
 /**
- * This example demonstrates how to take the screenshot of the web page.
+ * This example demonstrates how to take a screenshot of the whole web page including the part that is not visible on the screen.
  */
 public final class WebPageScreenshot {
 

--- a/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
+++ b/tutorials/taking-screenshots/src/main/java/com/teamdev/jxbrowser/examples/screenshot/WebPageScreenshot.java
@@ -69,7 +69,7 @@ public final class WebPageScreenshot {
             var image = BitmapImage.toToolkit(bitmap);
 
             // Save the image to a PNG file.
-            ImageIO.write(image, "PNG", new File("bitmap.png"));
+            ImageIO.write(image, "PNG", new File("html5test.teamdev.com.png"));
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
In this changeset, I have added the code for the tutorial, explaining how to take a screenshot of the web page in JxBrowser.

Issue: TeamDev-IP/JxBrowser-Docs/issues/1522