### PR TITLE
Use `TypeKeyCallback` to suppress keys

### DIFF
--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/SuppressKey.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/SuppressKey.java
@@ -23,7 +23,7 @@ package com.teamdev.jxbrowser.examples;
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
 import static java.lang.Character.isDigit;
 
-import com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback;
+import com.teamdev.jxbrowser.browser.callback.input.TypeKeyCallback;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
@@ -34,12 +34,12 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to suppress numbers typing using {@code PressKeyCallback}.
+ * This example demonstrates how to suppress numbers typing using {@code TypeKeyCallback}.
  *
  * <p>For suppressing other keyboard events the following callbacks are used:
  * <ul>
+ * <li>{@code PressKeyCallback}</li>
  * <li>{@code ReleaseKeyCallback}</li>
- * <li>{@code TypeKeyCallback}</li>
  * </ul>
  */
 public final class SuppressKey {
@@ -48,11 +48,11 @@ public final class SuppressKey {
         var engine = Engine.newInstance(HARDWARE_ACCELERATED);
         var browser = engine.newBrowser();
 
-        browser.set(PressKeyCallback.class, params -> {
+        browser.set(TypeKeyCallback.class, params -> {
             if (isDigit(params.event().keyChar())) {
-                return PressKeyCallback.Response.suppress();
+                return TypeKeyCallback.Response.suppress();
             }
-            return PressKeyCallback.Response.proceed();
+            return TypeKeyCallback.Response.proceed();
         });
 
         SwingUtilities.invokeLater(() -> {

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/SuppressKey.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/SuppressKey.kt
@@ -22,7 +22,7 @@ package com.teamdev.jxbrowser.examples
 
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.window.singleWindowApplication
-import com.teamdev.jxbrowser.browser.callback.input.PressKeyCallback
+import com.teamdev.jxbrowser.browser.callback.input.TypeKeyCallback
 import com.teamdev.jxbrowser.dsl.Engine
 import com.teamdev.jxbrowser.dsl.browser.mainFrame
 import com.teamdev.jxbrowser.dsl.register
@@ -31,26 +31,26 @@ import com.teamdev.jxbrowser.view.compose.BrowserView
 
 /**
  * This example demonstrates how to suppress numbers typing
- * using [PressKeyCallback].
+ * using [TypeKeyCallback].
  *
  * For suppressing other keyboard events the following callbacks are used:
  *
+ * - `PressKeyCallback`
  * - `ReleaseKeyCallback`
- * - `TypeKeyCallback`
  */
 fun main() {
     val engine = Engine(RenderingMode.OFF_SCREEN)
     val browser = engine.newBrowser()
 
-    browser.register(PressKeyCallback { params ->
+    browser.register(TypeKeyCallback { params ->
         if (params.event().keyChar().isDigit()) {
-            PressKeyCallback.Response.suppress()
+            TypeKeyCallback.Response.suppress()
         } else {
-            PressKeyCallback.Response.proceed()
+            TypeKeyCallback.Response.proceed()
         }
     })
 
-    singleWindowApplication(title = "Suppress `KeyPressed` event") {
+    singleWindowApplication(title = "Suppress `KeyPress` event") {
         BrowserView(browser)
         LaunchedEffect(Unit) {
             browser.mainFrame?.loadHtml("<textarea></textarea>")


### PR DESCRIPTION
Suppressing the `KeyDown` JavaScript event does not prevent the key from appearing in the text area. We need to use the `TypeKeyCallback` instead. This pull request switches the sample application from `PressKeyCallback` to `TypeKeyCallback`.

Issue: TeamDev-IP/JxBrowser-Docs#966