### PR TITLE
Rename open popup callback examples for Compose

### DIFF
--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/OpenExtensionPopupCallback.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/OpenExtensionPopupCallback.kt
@@ -56,7 +56,7 @@ import kotlinx.coroutines.launch
  * steps to achieve this functionality.
  */
 fun main() = singleWindowApplication(
-    title = "Default `OpenExtensionPopupCallback`",
+    title = "OpenExtensionPopupCallback",
     state = WindowState(size = DpSize(1280.dp, 900.dp))
 ) {
     val engine = remember { Engine(RenderingMode.OFF_SCREEN) }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/OpenPopupCallback.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/compose/OpenPopupCallback.kt
@@ -37,13 +37,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 /**
- * This example demonstrates the default [OpenPopupCallback] implementation
+ * This example demonstrates the [OpenPopupCallback] implementation
  * for Compose UI toolkit.
  *
  * It creates and shows a new window with the embedded pop-up browser
  * each time [OpenPopupCallback] is invoked.
  */
-fun main() = singleWindowApplication(title = "Default `OpenPopupCallback`") {
+fun main() = singleWindowApplication(title = "OpenPopupCallback") {
     val engine = remember { Engine(RenderingMode.OFF_SCREEN) }
     val browser = remember { engine.newBrowser() }
 


### PR DESCRIPTION
Rename open popup callback examples for Compose so they won't be confused with Java's examples. We show the default implementations of callbacks in Java. Those are used by default when the user has not set a callback. In Compose, there are no default implementations. These examples show how to use the open popup callbacks.