### PR TITLE
Update the `UserAgent` example to explain how to override the User-Agent Client Hints

### DIFF
--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
@@ -20,10 +20,13 @@
 
 package com.teamdev.jxbrowser.examples;
 
+import com.teamdev.jxbrowser.browser.Browser;
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
 
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.engine.EngineOptions;
+import com.teamdev.jxbrowser.net.UserAgentBrand;
+import com.teamdev.jxbrowser.net.UserAgentData;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import java.awt.BorderLayout;
 import java.awt.event.WindowAdapter;
@@ -33,7 +36,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to configure the Engine with a custom user agent string.
+ * This example demonstrates how to configure the {@code Engine} with a custom user agent string
+ * and override the user agent hints.
  */
 public final class UserAgent {
 
@@ -43,6 +47,7 @@ public final class UserAgent {
                         .userAgent("My User Agent String")
                         .build());
         var browser = engine.newBrowser();
+        setUserAgentHints(browser);
 
         SwingUtilities.invokeLater(() -> {
             var view = BrowserView.newInstance(browser);
@@ -62,5 +67,22 @@ public final class UserAgent {
         });
 
         browser.navigation().loadUrl("https://www.whatismybrowser.com/detect/what-is-my-user-agent/");
+    }
+
+    private static void setUserAgentHints(Browser browser) {
+        var data = UserAgentData.newBuilder()
+                .addBrand(UserAgentBrand.create("MyBrand", "1"))
+                .addBrand(UserAgentBrand.create("MyBrand2", "2"))
+                .addFormFactor("MyFormFactor")
+                .fullVersion("1.0")
+                .platform("MyOS")
+                .platformVersion("1.0")
+                .architecture("x86")
+                .bitness("32")
+                .model("MyModel")
+                .mobile(true)
+                .wow64(true)
+                .build();
+        browser.userAgentData(data);
     }
 }

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
@@ -36,7 +36,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to configure the {@code Engine} with a custom User-Agent string
+ * This example demonstrates how to configure the {@code Browser} with a custom User-Agent string
  * and override the User-Agent Client Hints.
  */
 public final class UserAgent {

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
@@ -69,7 +69,7 @@ public final class UserAgent {
         browser.navigation().loadUrl("https://www.whatismybrowser.com/detect/what-is-my-user-agent/");
     }
 
-    private static void setUserAgentHints(Browser browser) {
+    private static void setUserAgentClientHints(Browser browser) {
         var data = UserAgentData.newBuilder()
                 .addBrand(UserAgentBrand.create("MyBrand", "1"))
                 .addBrand(UserAgentBrand.create("MyBrand2", "2"))

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
@@ -36,8 +36,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /**
- * This example demonstrates how to configure the {@code Engine} with a custom user agent string
- * and override the user agent hints.
+ * This example demonstrates how to configure the {@code Engine} with a custom User-Agent string
+ * and override the User-Agent Client Hints.
  */
 public final class UserAgent {
 

--- a/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
+++ b/examples/src/main/java/com/teamdev/jxbrowser/examples/UserAgent.java
@@ -47,7 +47,7 @@ public final class UserAgent {
                         .userAgent("My User Agent String")
                         .build());
         var browser = engine.newBrowser();
-        setUserAgentHints(browser);
+        setUserAgentClientHints(browser);
 
         SwingUtilities.invokeLater(() -> {
             var view = BrowserView.newInstance(browser);

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
@@ -33,7 +33,7 @@ import com.teamdev.jxbrowser.net.UserAgentData
 import com.teamdev.jxbrowser.view.compose.BrowserView
 
 /**
- * This example demonstrates how to configure the [Engine] with a custom User-Agent string
+ * This example demonstrates how to configure the [Browser] with a custom User-Agent string
  * and override the User-Agent Client Hints.
  */
 fun main() {

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
@@ -42,7 +42,7 @@ fun main() {
     }
 
     val browser = engine.newBrowser()
-    setUserAgentHints(browser)
+    setUserAgentClientHints(browser)
 
     singleWindowApplication(title = "Custom user agent") {
         BrowserView(browser)

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
@@ -22,15 +22,19 @@ package com.teamdev.jxbrowser.examples
 
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.window.singleWindowApplication
+import com.teamdev.jxbrowser.browser.Browser
 import com.teamdev.jxbrowser.dsl.Engine
 import com.teamdev.jxbrowser.dsl.browser.navigation
 import com.teamdev.jxbrowser.dsl.engine.UserAgent
 import com.teamdev.jxbrowser.engine.Engine
 import com.teamdev.jxbrowser.engine.RenderingMode
+import com.teamdev.jxbrowser.net.UserAgentBrand
+import com.teamdev.jxbrowser.net.UserAgentData
 import com.teamdev.jxbrowser.view.compose.BrowserView
 
 /**
- * This example demonstrates how to configure [Engine] with a custom user agent.
+ * This example demonstrates how to configure the [Engine] with a custom user agent string
+ * and override the user agent hints.
  */
 fun main() {
     val engine = Engine(RenderingMode.OFF_SCREEN) {
@@ -38,6 +42,7 @@ fun main() {
     }
 
     val browser = engine.newBrowser()
+    setUserAgentHints(browser)
 
     singleWindowApplication(title = "Custom user agent") {
         BrowserView(browser)
@@ -45,4 +50,21 @@ fun main() {
             browser.navigation.loadUrl("https://www.whatismybrowser.com/detect/what-is-my-user-agent/")
         }
     }
+}
+
+private fun setUserAgentHints(browser: Browser) {
+    val data = UserAgentData.newBuilder()
+        .addBrand(UserAgentBrand.create("MyBrand", "1"))
+        .addBrand(UserAgentBrand.create("MyBrand2", "2"))
+        .addFormFactor("MyFormFactor")
+        .fullVersion("1.0")
+        .platform("MyOS")
+        .platformVersion("1.0")
+        .architecture("x86")
+        .bitness("32")
+        .model("MyModel")
+        .mobile(true)
+        .wow64(true)
+        .build()
+    browser.userAgentData(data)
 }

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
@@ -52,7 +52,7 @@ fun main() {
     }
 }
 
-private fun setUserAgentHints(browser: Browser) {
+private fun setUserAgentClientHints(browser: Browser) {
     val data = UserAgentData.newBuilder()
         .addBrand(UserAgentBrand.create("MyBrand", "1"))
         .addBrand(UserAgentBrand.create("MyBrand2", "2"))

--- a/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
+++ b/examples/src/main/kotlin/com/teamdev/jxbrowser/examples/UserAgent.kt
@@ -33,8 +33,8 @@ import com.teamdev.jxbrowser.net.UserAgentData
 import com.teamdev.jxbrowser.view.compose.BrowserView
 
 /**
- * This example demonstrates how to configure the [Engine] with a custom user agent string
- * and override the user agent hints.
+ * This example demonstrates how to configure the [Engine] with a custom User-Agent string
+ * and override the User-Agent Client Hints.
  */
 fun main() {
     val engine = Engine(RenderingMode.OFF_SCREEN) {


### PR DESCRIPTION
In this changeset, we have updated the `UserAgent` example to explain how to override the user agent hints.

Issue: TeamDev-IP/JxBrowser-Docs/issues/2552