### PR TITLE
Update Ubuntu version for GitHub Action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,7 +3,7 @@ on: pull_request
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
In this changeset, we change Ubuntu to 24.04 because 20.04 image is no more on GitHub Actions.

https://github.com/actions/runner-images/issues/11101