### PR TITLE
Do not ignore the IDEA config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.iml
 .idea/libraries
 .idea/shelf
-.idea/*.*
 
 # Do not ignore code style settings.
 !/.idea/codeStyleSettings.xml


### PR DESCRIPTION
In this changeset, we have updated `.gitignore` to stop ignoring the IDEA config files.